### PR TITLE
[Feat] Ajout du style SelectField

### DIFF
--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -12,6 +12,7 @@
 @import "../../components/header/header";
 @import "../../components/button/button";
 @import "../../components/checkbox/input-checkbox";
+@import "../../components/forms/SelectField";
 
 @import "../../home/slider/slider";
 @import "../../home/about/about";

--- a/src/components/forms/SelectField.tsx
+++ b/src/components/forms/SelectField.tsx
@@ -1,5 +1,6 @@
 // src/components/SelectField.tsx
 import React from "react";
+import "./_SelectField.scss";
 
 interface Option {
     value: string;
@@ -29,8 +30,11 @@ export default function SelectField({
     const id = `select-${name}`;
 
     return (
-        <div className="mb-2">
-            <label htmlFor={id} className={hideLabel ? "sr-only" : "block font-medium mb-1"}>
+        <div className="select-field">
+            <label
+                htmlFor={id}
+                className={hideLabel ? "sr-only select-field_label" : "select-field_label"}
+            >
                 {label}
             </label>
             <select
@@ -39,7 +43,7 @@ export default function SelectField({
                 value={value}
                 onChange={onChange}
                 required={required}
-                className="border p-2 w-full rounded bg-white"
+                className="select-field_input"
                 {...rest}
             >
                 {options.map((opt) => (

--- a/src/components/forms/_SelectField.scss
+++ b/src/components/forms/_SelectField.scss
@@ -1,0 +1,17 @@
+.select-field {
+    margin-bottom: 0.5rem;
+}
+
+.select-field_label {
+    display: block;
+    font-weight: 500;
+    margin-bottom: 0.25rem;
+}
+
+.select-field_input {
+    border: 1px solid $grey;
+    padding: 0.5rem;
+    width: 100%;
+    background: $white;
+    @include border-radius(4px);
+}


### PR DESCRIPTION
## Description
- remplace les classes Tailwind de `SelectField` par des classes SCSS dédiées
- ajoute le fichier de styles `_SelectField.scss` et son import dans `main.scss`

## Tests effectués
- `yarn install`
- `yarn prettier --write src/components/forms/SelectField.tsx src/components/forms/_SelectField.scss src/assets/styles/main.scss`
- `yarn lint` (avertissements sur des `<img>` existants)
- `yarn build` *(échoué : Module not found: Can't resolve '@/amplify_outputs.json')*

------
https://chatgpt.com/codex/tasks/task_e_68ade47add148324a7463d996dd1e9b2