### PR TITLE
[Feat] style UserNameManager

### DIFF
--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -12,6 +12,7 @@
 @import "../../components/header/header";
 @import "../../components/button/button";
 @import "../../components/checkbox/input-checkbox";
+@import "../../components/Profile/UserNameManager";
 
 @import "../../home/slider/slider";
 @import "../../home/about/about";

--- a/src/components/Profile/UserNameManager.tsx
+++ b/src/components/Profile/UserNameManager.tsx
@@ -6,6 +6,7 @@ import "@aws-amplify/ui-react/styles.css";
 import EntityEditor from "@components/forms/EntityEditor";
 import { label as fieldLabel } from "./utilsUserName";
 import PersonIcon from "@mui/icons-material/Person";
+import "./_UserNameManager.scss";
 import { useUserNameForm } from "@entities/models/userName/hooks";
 import {
     type UserNameFormType,
@@ -31,7 +32,7 @@ export default function UserNameManager() {
             title="Mon pseudo public"
             requiredFields={["userName"]}
             deleteLabel="Supprimer le pseudo"
-            renderIcon={() => <PersonIcon fontSize="small" className="text-gray-800" />}
+            renderIcon={() => <PersonIcon fontSize="small" className="user-name-manager_icon" />}
             onClearField={(field, clear) => {
                 if (
                     confirm(

--- a/src/components/Profile/_UserNameManager.scss
+++ b/src/components/Profile/_UserNameManager.scss
@@ -1,0 +1,3 @@
+.user-name-manager_icon {
+    color: $primary-black;
+}


### PR DESCRIPTION
## Description
- ajoute `_UserNameManager.scss` pour appliquer `$primary-black` à l’icône
- remplace `text-gray-800` par `user-name-manager_icon`
- importe la feuille de style dans `UserNameManager.tsx` et `main.scss`

## Tests effectués
- `yarn install`
- `yarn prettier --write src/components/Profile/UserNameManager.tsx src/components/Profile/_UserNameManager.scss src/assets/styles/main.scss`
- `yarn lint`
- `yarn build` *(échoue : Module not found `@/amplify_outputs.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68ade46f70a08324899ba6b7614872fe