### PR TITLE
[Feat] externaliser les styles d'EntityForm

### DIFF
--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -21,6 +21,7 @@
 @import "../../components/forms/ItemSelector";
 @import "../../components/forms/EditField";
 @import "../../components/forms/EditableField";
+@import "../../components/forms/EntityForm";
 
 @import "../../home/slider/slider";
 @import "../../home/about/about";

--- a/src/components/forms/EntityForm.tsx
+++ b/src/components/forms/EntityForm.tsx
@@ -3,6 +3,7 @@
 import React, { type FormEvent } from "react";
 import { SaveButton, AddButton, CancelButton } from "@components/buttons";
 import { type FieldKey } from "@entities/core/hooks";
+import "./_EntityForm.scss";
 
 type Props<T extends Record<string, unknown>> = {
     formData: Partial<T>;
@@ -31,26 +32,23 @@ export default function EntityForm<T extends Record<string, unknown>>({
                 e.preventDefault();
                 handleSubmit();
             }}
-            className="space-y-5 p-6 bg-white border rounded-md shadow-sm max-w-md mx-auto"
+            className="entity-form"
         >
             {fields.map((field) => (
-                <div key={String(field)}>
-                    <label htmlFor={String(field)} className="block mb-1 font-medium">
-                        {labels(field)}
-                    </label>
+                <div key={String(field)} className="entity-form_field">
+                    <label htmlFor={String(field)}>{labels(field)}</label>
                     <input
                         id={String(field)}
                         name={String(field)}
                         placeholder={labels(field)}
                         value={String(formData[field] ?? "")}
                         onChange={(e) => handleChange(field, e.target.value)}
-                        className="w-full p-2 border rounded"
                         required={requiredFields.includes(field)}
                     />
                 </div>
             ))}
 
-            <div className="flex justify-end gap-2 pt-2">
+            <div className="entity-form_actions">
                 {isEdit ? (
                     <>
                         <SaveButton

--- a/src/components/forms/_EntityForm.scss
+++ b/src/components/forms/_EntityForm.scss
@@ -1,0 +1,35 @@
+.entity-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem; // space-y-5
+    padding: 1.5rem; // p-6
+    background: $white; // bg-white
+    border: 1px solid $grey; // border
+    @include border-radius(6px); // rounded-md
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05); // shadow-sm
+    max-width: 28rem; // max-w-md
+    margin-left: auto; // mx-auto
+    margin-right: auto; // mx-auto
+}
+
+.entity-form_field {
+    label {
+        display: block; // block
+        margin-bottom: 0.25rem; // mb-1
+        font-weight: 500; // font-medium
+    }
+
+    input {
+        width: 100%; // w-full
+        padding: 0.5rem; // p-2
+        border: 1px solid $grey; // border
+        @include border-radius(4px); // rounded
+    }
+}
+
+.entity-form_actions {
+    display: flex; // flex
+    justify-content: flex-end; // justify-end
+    gap: 0.5rem; // gap-2
+    padding-top: 0.5rem; // pt-2
+}


### PR DESCRIPTION
## Description
- isole les styles du formulaire des entités dans un fichier SCSS dédié
- remplace les classes utilitaires par `entity-form`, `entity-form_field` et `entity-form_actions`
- importe le style dans `EntityForm.tsx` et `main.scss`

## Tests effectués
- `yarn lint`
- `yarn build` *(échoué: Module not found '@/amplify_outputs.json')*


------
https://chatgpt.com/codex/tasks/task_e_68ade8461c288324bfc0d762f39fe2c4