### PR TITLE
[Feat] styliser EntityEditor via SCSS et clsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "@mui/icons-material": "^7.1.0",
         "@mui/material": "^7.1.0",
         "aws-amplify": "^6.14.4",
+        "clsx": "^2.1.1",
         "next": "15.0.3",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",

--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -21,6 +21,7 @@
 @import "../../components/forms/ItemSelector";
 @import "../../components/forms/EditField";
 @import "../../components/forms/EditableField";
+@import "../../components/forms/EntityEditor";
 
 @import "../../home/slider/slider";
 @import "../../home/about/about";

--- a/src/components/forms/EntityEditor.tsx
+++ b/src/components/forms/EntityEditor.tsx
@@ -1,10 +1,12 @@
 "use client";
 import React, { useState } from "react";
+import clsx from "clsx";
 import type { FieldKey, FormMode } from "@entities/core/hooks";
 import ReadOnlyView from "./ReadOnlyView";
 import EditField from "./EditField";
 import EntityForm from "./EntityForm";
 import { DeleteButton } from "@components/buttons";
+import "./_EntityEditor.scss";
 
 export type EntityEditorProps<T extends Record<string, unknown>> = {
     /** Titre de la section */
@@ -92,12 +94,8 @@ export default function EntityEditor<T extends Record<string, unknown>>(
     };
 
     return (
-        <section
-            className={`w-full max-w-md mx-auto px-4 py-6 bg-white shadow rounded-lg mb-8 ${
-                className ?? ""
-            }`}
-        >
-            <h1 className="text-2xl font-bold text-center mb-6">{title}</h1>
+        <section className={clsx("entity-editor", className)}>
+            <h1 className="entity-editor_title">{title}</h1>
 
             {mode === "edit" && !editModeField && (
                 <ReadOnlyView<T>
@@ -142,7 +140,7 @@ export default function EntityEditor<T extends Record<string, unknown>>(
             )}
 
             {mode === "edit" && !editModeField && deleteLabel && (
-                <div className="flex items-center justify-center mt-8">
+                <div className="entity-editor_delete-container">
                     <DeleteButton
                         onClick={() => {
                             void deleteEntity?.();

--- a/src/components/forms/_EntityEditor.scss
+++ b/src/components/forms/_EntityEditor.scss
@@ -1,0 +1,25 @@
+.entity-editor {
+    width: 100%;
+    max-width: 28rem;
+    margin: 0 auto 2rem;
+    padding: 1.5rem 1rem;
+    background-color: $white;
+    box-shadow:
+        0 1px 3px rgba(0, 0, 0, 0.1),
+        0 1px 2px -1px rgba(0, 0, 0, 0.1);
+    border-radius: 0.5rem;
+
+    &_title {
+        font-size: 1.5rem;
+        font-weight: 700;
+        text-align: center;
+        margin-bottom: 1.5rem;
+    }
+
+    &_delete-container {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin-top: 2rem;
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -16575,6 +16575,7 @@ __metadata:
     aws-amplify: "npm:^6.14.4"
     aws-cdk: "npm:^2"
     aws-cdk-lib: "npm:^2"
+    clsx: "npm:^2.1.1"
     constructs: "npm:^10.3.0"
     esbuild: "npm:^0.23.1"
     eslint: "npm:^9.15.0"


### PR DESCRIPTION
## Description
- centralise le style d'`EntityEditor` dans un fichier SCSS dédié
- fusion des classes avec `clsx`
- import du style dans `main.scss`

## Tests effectués
- `yarn lint`
- `yarn build` *(échoue : Can't resolve '@/amplify_outputs.json')*


------
https://chatgpt.com/codex/tasks/task_e_68ade847f5648324ac421f8fc04bb497