### PR TITLE
[Feat] styliser l'authentificateur Amplify

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import { type Metadata } from "next";
 import metaData from "./metaData";
 import localFont from "next/font/local";
 import "../src/assets/styles/main.scss";
+import "../src/styles/amplify/authenticator.scss";
 import { DrivingProvider } from "../src/utils/context/DrivingContext";
 import { SearchProvider } from "../src/utils/context/SearchContext";
 import { Suspense } from "react";

--- a/src/styles/amplify/README.md
+++ b/src/styles/amplify/README.md
@@ -1,0 +1,17 @@
+# Styles Amplify Authenticator
+
+Ce dossier regroupe les styles nécessaires à l'authentification basée sur AWS Amplify.
+
+## Variables
+
+`_auth.variables.scss` centralise les tokens CSS extraits du thème Amplify (Button, FieldControl, Authenticator). Elles permettent d'adapter les couleurs, espacements et rayons utilisés par le composant.
+
+## Mixins
+
+`_auth.mixins.scss` propose des mixins `auth-button` et `auth-input` afin de répliquer rapidement l'apparence par défaut tout en facilitant les overrides.
+
+## Tailles
+
+`_auth.form.scss` contient les déclinaisons `--small` et `--large` utilisées par les champs de formulaire.
+
+Ajoutez vos personnalisations dans `_auth.overrides.scss`.

--- a/src/styles/amplify/_auth.core.scss
+++ b/src/styles/amplify/_auth.core.scss
@@ -1,0 +1,119 @@
+@import "./auth.mixins";
+
+/* Authenticator container and modal */
+[data-amplify-authenticator] {
+    @include auth-container;
+}
+
+[data-amplify-authenticator][data-variation="modal"] {
+    overflow-y: auto;
+    width: var(--amplify-components-authenticator-modal-width);
+    height: var(--amplify-components-authenticator-modal-height);
+    background-color: var(--amplify-components-authenticator-modal-background-color);
+    position: fixed;
+    top: var(--amplify-components-authenticator-modal-top);
+    left: var(--amplify-components-authenticator-modal-left);
+    z-index: 1;
+}
+
+[data-amplify-authenticator] [data-amplify-container] {
+    place-self: center;
+}
+
+@media (min-width: 30rem) {
+    [data-amplify-authenticator] [data-amplify-container] {
+        width: var(--amplify-components-authenticator-container-width-max);
+    }
+}
+
+[data-amplify-authenticator] [data-amplify-router] {
+    background-color: var(--amplify-components-authenticator-router-background-color);
+    box-shadow: var(--amplify-components-authenticator-router-box-shadow);
+    border-color: var(--amplify-components-authenticator-router-border-color);
+    border-width: var(--amplify-components-authenticator-router-border-width);
+    border-style: var(--amplify-components-authenticator-router-border-style);
+}
+
+[data-amplify-authenticator] [data-amplify-footer] {
+    padding-bottom: var(--amplify-components-authenticator-footer-padding-bottom);
+    text-align: center;
+}
+
+[data-amplify-authenticator] [data-amplify-form] {
+    padding: var(--amplify-components-authenticator-form-padding);
+}
+
+[data-amplify-authenticator] [data-state="inactive"] {
+    background-color: var(--amplify-components-authenticator-state-inactive-background-color);
+}
+
+@media (max-width: 26rem) {
+    [data-amplify-authenticator] [data-amplify-sign-up-errors] {
+        font-size: 0.688rem;
+    }
+}
+
+/* Buttons */
+.amplify-button {
+    @include auth-button;
+    --amplify-internal-button-background-color: var(--amplify-components-button-background-color);
+    --amplify-internal-button-border-color: var(--amplify-components-button-border-color);
+    --amplify-internal-button-color: var(--amplify-components-button-color);
+    --amplify-internal-button-focus-box-shadow: var(--amplify-components-button-focus-box-shadow);
+    --amplify-internal-button-border-width: var(--amplify-components-button-border-width);
+}
+
+.amplify-button:hover {
+    --amplify-internal-button-background-color: var(
+        --amplify-components-button-hover-background-color
+    );
+    --amplify-internal-button-border-color: var(--amplify-components-button-hover-border-color);
+    --amplify-internal-button-color: var(--amplify-components-button-hover-color);
+}
+
+.amplify-button:focus {
+    --amplify-internal-button-background-color: var(
+        --amplify-components-button-hover-background-color
+    );
+    --amplify-internal-button-border-color: var(--amplify-components-button-focus-border-color);
+    --amplify-internal-button-color: var(--amplify-components-button-focus-color);
+    box-shadow: var(--amplify-internal-button-focus-box-shadow);
+}
+
+.amplify-button:active {
+    --amplify-internal-button-background-color: var(
+        --amplify-components-button-active-background-color
+    );
+    --amplify-internal-button-border-color: var(--amplify-components-button-active-border-color);
+    --amplify-internal-button-color: var(--amplify-components-button-active-color);
+}
+
+.amplify-button--fullwidth {
+    width: 100%;
+}
+
+/* Inputs */
+.amplify-input {
+    @include auth-input;
+}
+
+.amplify-input:focus {
+    border-color: var(--amplify-components-fieldcontrol-focus-border-color);
+    box-shadow: var(--amplify-components-fieldcontrol-focus-box-shadow);
+}
+
+.amplify-input--error {
+    border-color: var(--amplify-components-fieldcontrol-error-border-color);
+}
+
+.amplify-input--error:focus {
+    border-color: var(--amplify-components-fieldcontrol-error-border-color);
+    box-shadow: var(--amplify-components-fieldcontrol-error-focus-box-shadow);
+}
+
+.amplify-input[disabled] {
+    color: var(--amplify-components-fieldcontrol-disabled-color);
+    cursor: var(--amplify-components-fieldcontrol-disabled-cursor);
+    border-color: var(--amplify-components-fieldcontrol-disabled-border-color);
+    background-color: var(--amplify-components-fieldcontrol-disabled-background-color);
+}

--- a/src/styles/amplify/_auth.form.scss
+++ b/src/styles/amplify/_auth.form.scss
@@ -1,0 +1,16 @@
+/* Size variants */
+.amplify-input--small {
+    font-size: var(--amplify-components-fieldcontrol-small-font-size);
+    padding-block-start: var(--amplify-components-fieldcontrol-small-padding-block-start);
+    padding-block-end: var(--amplify-components-fieldcontrol-small-padding-block-end);
+    padding-inline-start: var(--amplify-components-fieldcontrol-small-padding-inline-start);
+    padding-inline-end: var(--amplify-components-fieldcontrol-small-padding-inline-end);
+}
+
+.amplify-input--large {
+    font-size: var(--amplify-components-fieldcontrol-large-font-size);
+    padding-block-start: var(--amplify-components-fieldcontrol-large-padding-block-start);
+    padding-block-end: var(--amplify-components-fieldcontrol-large-padding-block-end);
+    padding-inline-start: var(--amplify-components-fieldcontrol-large-padding-inline-start);
+    padding-inline-end: var(--amplify-components-fieldcontrol-large-padding-inline-end);
+}

--- a/src/styles/amplify/_auth.mixins.scss
+++ b/src/styles/amplify/_auth.mixins.scss
@@ -1,0 +1,41 @@
+@mixin auth-container {
+    display: grid;
+}
+
+@mixin auth-button {
+    font-weight: var(--amplify-components-button-font-weight);
+    font-size: var(--amplify-components-button-font-size);
+    line-height: var(--amplify-components-button-line-height);
+    padding-block-start: var(--amplify-components-button-padding-block-start);
+    padding-block-end: var(--amplify-components-button-padding-block-end);
+    padding-inline-start: var(--amplify-components-button-padding-inline-start);
+    padding-inline-end: var(--amplify-components-button-padding-inline-end);
+    border-width: var(--amplify-components-button-border-width);
+    border-style: var(--amplify-components-button-border-style);
+    border-color: var(--amplify-components-button-border-color);
+    border-radius: var(--amplify-components-button-border-radius);
+    background-color: var(--amplify-components-button-background-color);
+    color: var(--amplify-components-button-color);
+    transition: all var(--amplify-components-button-transition-duration);
+}
+
+@mixin auth-input {
+    box-sizing: border-box;
+    color: var(--amplify-components-fieldcontrol-color);
+    font-size: var(--amplify-components-fieldcontrol-font-size);
+    line-height: var(--amplify-components-fieldcontrol-line-height);
+    padding-block-start: var(--amplify-components-fieldcontrol-padding-block-start);
+    padding-block-end: var(--amplify-components-fieldcontrol-padding-block-end);
+    padding-inline-start: var(--amplify-components-fieldcontrol-padding-inline-start);
+    padding-inline-end: var(--amplify-components-fieldcontrol-padding-inline-end);
+    border-width: var(--amplify-components-fieldcontrol-border-width);
+    border-style: var(--amplify-components-fieldcontrol-border-style);
+    border-color: var(--amplify-components-fieldcontrol-border-color);
+    border-radius: var(--amplify-components-fieldcontrol-border-radius);
+    transition: all var(--amplify-components-fieldcontrol-transition-duration);
+    width: 100%;
+    outline-color: var(--amplify-components-fieldcontrol-outline-color);
+    outline-style: var(--amplify-components-fieldcontrol-outline-style);
+    outline-width: var(--amplify-components-fieldcontrol-outline-width);
+    outline-offset: var(--amplify-components-fieldcontrol-outline-offset);
+}

--- a/src/styles/amplify/_auth.overrides.scss
+++ b/src/styles/amplify/_auth.overrides.scss
@@ -1,0 +1,1 @@
+/* Extensions et surcharges spécifiques au projet */

--- a/src/styles/amplify/_auth.variables.scss
+++ b/src/styles/amplify/_auth.variables.scss
@@ -1,0 +1,77 @@
+:root {
+    /* Authenticator */
+    --amplify-components-authenticator-max-width: 60rem;
+    --amplify-components-authenticator-modal-width: var(--amplify-space-relative-full);
+    --amplify-components-authenticator-modal-height: var(--amplify-space-relative-full);
+    --amplify-components-authenticator-modal-background-color: var(--amplify-colors-overlay-50);
+    --amplify-components-authenticator-modal-top: var(--amplify-space-zero);
+    --amplify-components-authenticator-modal-left: var(--amplify-space-zero);
+    --amplify-components-authenticator-container-width-max: 30rem;
+    --amplify-components-authenticator-router-border-width: var(--amplify-border-widths-small);
+    --amplify-components-authenticator-router-border-style: solid;
+    --amplify-components-authenticator-router-border-color: var(--amplify-colors-border-primary);
+
+    /* Field control */
+    --amplify-components-fieldcontrol-transition-duration: var(--amplify-time-medium);
+    --amplify-components-fieldcontrol-font-size: var(--amplify-font-sizes-medium);
+    --amplify-components-fieldcontrol-line-height: var(--amplify-line-heights-medium);
+    --amplify-components-fieldcontrol-padding-block-start: var(--amplify-space-xs);
+    --amplify-components-fieldcontrol-padding-block-end: var(--amplify-space-xs);
+    --amplify-components-fieldcontrol-padding-inline-start: var(--amplify-space-small);
+    --amplify-components-fieldcontrol-padding-inline-end: var(--amplify-space-small);
+    --amplify-components-fieldcontrol-border-color: var(--amplify-colors-border-primary);
+    --amplify-components-fieldcontrol-border-width: var(--amplify-border-widths-small);
+    --amplify-components-fieldcontrol-border-style: solid;
+    --amplify-components-fieldcontrol-border-radius: var(--amplify-radii-small);
+    --amplify-components-fieldcontrol-color: var(--amplify-colors-font-primary);
+    --amplify-components-fieldcontrol-focus-border-color: var(--amplify-colors-border-focus);
+    --amplify-components-fieldcontrol-focus-box-shadow: 0 0 0 2px var(--amplify-colors-border-focus);
+    --amplify-components-fieldcontrol-small-font-size: var(--amplify-font-sizes-small);
+    --amplify-components-fieldcontrol-small-padding-block-start: var(--amplify-space-xxs);
+    --amplify-components-fieldcontrol-small-padding-block-end: var(--amplify-space-xxs);
+    --amplify-components-fieldcontrol-small-padding-inline-start: var(--amplify-space-xs);
+    --amplify-components-fieldcontrol-small-padding-inline-end: var(--amplify-space-xs);
+    --amplify-components-fieldcontrol-large-font-size: var(--amplify-font-sizes-large);
+    --amplify-components-fieldcontrol-large-padding-block-start: var(--amplify-space-small);
+    --amplify-components-fieldcontrol-large-padding-block-end: var(--amplify-space-small);
+    --amplify-components-fieldcontrol-large-padding-inline-start: var(--amplify-space-medium);
+    --amplify-components-fieldcontrol-large-padding-inline-end: var(--amplify-space-medium);
+
+    /* Button */
+    --amplify-components-button-font-weight: var(--amplify-font-weights-bold);
+    --amplify-components-button-transition-duration: var(
+        --amplify-components-fieldcontrol-transition-duration
+    );
+    --amplify-components-button-font-size: var(--amplify-components-fieldcontrol-font-size);
+    --amplify-components-button-line-height: var(--amplify-components-fieldcontrol-line-height);
+    --amplify-components-button-padding-block-start: var(
+        --amplify-components-fieldcontrol-padding-block-start
+    );
+    --amplify-components-button-padding-block-end: var(
+        --amplify-components-fieldcontrol-padding-block-end
+    );
+    --amplify-components-button-padding-inline-start: var(
+        --amplify-components-fieldcontrol-padding-inline-start
+    );
+    --amplify-components-button-padding-inline-end: var(
+        --amplify-components-fieldcontrol-padding-inline-end
+    );
+    --amplify-components-button-background-color: transparent;
+    --amplify-components-button-border-color: var(--amplify-components-fieldcontrol-border-color);
+    --amplify-components-button-border-width: var(--amplify-components-fieldcontrol-border-width);
+    --amplify-components-button-border-style: var(--amplify-components-fieldcontrol-border-style);
+    --amplify-components-button-border-radius: var(--amplify-components-fieldcontrol-border-radius);
+    --amplify-components-button-color: var(--amplify-colors-font-primary);
+    --amplify-components-button-hover-color: var(--amplify-colors-font-focus);
+    --amplify-components-button-hover-background-color: var(--amplify-colors-primary-10);
+    --amplify-components-button-hover-border-color: var(--amplify-colors-primary-60);
+    --amplify-components-button-focus-color: var(--amplify-colors-font-focus);
+    --amplify-components-button-focus-background-color: var(--amplify-colors-primary-10);
+    --amplify-components-button-focus-border-color: var(--amplify-colors-border-focus);
+    --amplify-components-button-focus-box-shadow: var(
+        --amplify-components-fieldcontrol-focus-box-shadow
+    );
+    --amplify-components-button-active-color: var(--amplify-colors-font-active);
+    --amplify-components-button-active-background-color: var(--amplify-colors-primary-20);
+    --amplify-components-button-active-border-color: var(--amplify-colors-primary-100);
+}

--- a/src/styles/amplify/authenticator.scss
+++ b/src/styles/amplify/authenticator.scss
@@ -1,0 +1,5 @@
+@import "./auth.variables";
+@import "./auth.mixins";
+@import "./auth.core";
+@import "./auth.form";
+@import "./auth.overrides";


### PR DESCRIPTION
## Description
- introduit un dossier `src/styles/amplify` avec variables, mixins et styles de base de l'authentificateur
- importe le point d'entrée `authenticator.scss` dans `app/layout.tsx`

## Tests effectués
- `yarn lint`
- `yarn build` *(interrompu : la création du build n'a pas abouti dans l'environnement d'exécution)*

------
https://chatgpt.com/codex/tasks/task_e_68ae35ad61a083248d7644e1d8adc096