### PR TITLE
[Feat] configuration Vitest et tests du menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ This project uses [`next/font`](https://nextjs.org/docs/app/building-your-applic
 
 To learn more about Next.js, take a look at the following resources:
 
--   [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
--   [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
+- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
 
@@ -48,3 +48,13 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Tests
+
+Le projet utilise [Vitest](https://vitest.dev) et [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/) pour les tests unitaires.
+
+```bash
+yarn test
+```
+
+La commande ci-dessus exécute l’ensemble de la suite de tests.

--- a/__tests__/menu.update.test.ts
+++ b/__tests__/menu.update.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { isMainItemActive, updateMenuItems } from "@utils/updateMenuUtils";
+import type { MenuItem } from "@assets/data/menuItems";
+
+describe("updateMenuUtils", () => {
+    describe("isMainItemActive", () => {
+        it("détermine les chemins actifs", () => {
+            expect(isMainItemActive("/", "/")).toBe(true);
+            expect(isMainItemActive("/", "/#section")).toBe(true);
+            expect(isMainItemActive("/services", "/services/offre")).toBe(true);
+            expect(isMainItemActive("/blog", "/contact")).toBe(false);
+        });
+    });
+
+    describe("updateMenuItems", () => {
+        it("ajoute la classe active sur l’item et son sous-item correspondant", () => {
+            const items: MenuItem[] = [
+                {
+                    id: "main",
+                    title: "Main",
+                    class: "",
+                    path: "/services",
+                    AnchorId: "#top",
+                    subItems: [{ id: "sub", title: "Sub", AnchorId: "#section", class: "" }],
+                },
+                {
+                    id: "other",
+                    title: "Other",
+                    class: "",
+                    path: "/other",
+                    AnchorId: "#top",
+                },
+            ];
+            const res = updateMenuItems(items, "section", "/services");
+            expect(res[0].class).toBe("active");
+            expect(res[0].subItems?.[0].class).toBe("active");
+            expect(res[1].class).toBe("");
+        });
+    });
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
         "build": "next build",
         "start": "next start",
         "lint": "next lint",
-        "generate:sitemap": "node scripts/generate-sitemap.js"
+        "generate:sitemap": "node scripts/generate-sitemap.js",
+        "test": "vitest run"
     },
     "dependencies": {
         "@aws-amplify/auth": "^6.13.0",
@@ -44,6 +45,11 @@
         "esbuild": "^0.23.1",
         "eslint": "^9.15.0",
         "eslint-config-next": "15.0.3",
+        "@testing-library/react": "^16.0.0",
+        "@testing-library/jest-dom": "^6.4.1",
+        "jsdom": "^24.0.0",
+        "vitest": "^1.6.0",
+        "vite-tsconfig-paths": "^5.1.0",
         "prettier": "^3.6.2",
         "tsx": "^4.19.0",
         "typescript": "^5.6.2"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+    plugins: [tsconfigPaths()],
+    test: {
+        environment: "jsdom",
+        globals: true,
+        setupFiles: "./vitest.setup.ts",
+    },
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";


### PR DESCRIPTION
## Description
- ajoute le script `yarn test`
- configure Vitest (jsdom + paths)
- documente l'exécution des tests
- ajoute un test de non‑régression sur les utils du menu

## Tests effectués
- `yarn prettier --write package.json vitest.config.ts vitest.setup.ts __tests__/menu.update.test.ts README.md`
- `yarn lint`
- `yarn test` *(échoue : `vitest` introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68af4e18cf648324b7eb7ed8eecd6b96