### PR TITLE
[Feat] Ajout des utilitaires de menu

### DIFF
--- a/src/menu/a11y/keyboard.ts
+++ b/src/menu/a11y/keyboard.ts
@@ -1,0 +1,4 @@
+/**
+ * Helpers clavier pour l'accessibilité.
+ */
+export const isEscape = (e: KeyboardEvent): boolean => e.key === "Escape";

--- a/src/menu/actions/adapter.ts
+++ b/src/menu/actions/adapter.ts
@@ -1,0 +1,29 @@
+import type { MenuItem } from "@assets/data/interfaces/menu";
+import type { ExternalActionMap, MenuAction } from "./types";
+
+/**
+ * Convertit un MenuItem en MenuAction selon la priorité définie.
+ */
+export function toAction(item: MenuItem, external: ExternalActionMap): MenuAction {
+    if (item.subItems && item.subItems.length > 0) {
+        return { kind: "toggle", itemId: item.id };
+    }
+
+    if (external[item.id]) {
+        return { kind: "externalClick", handlerId: item.id };
+    }
+
+    if (item.path && item.AnchorId) {
+        return { kind: "href", href: `${item.path}${item.AnchorId}` };
+    }
+
+    if (item.AnchorId) {
+        return { kind: "hash", targetId: item.AnchorId.replace(/^#/, "") };
+    }
+
+    if (item.path) {
+        return { kind: "href", href: item.path };
+    }
+
+    return { kind: "toggle", itemId: item.id };
+}

--- a/src/menu/actions/dispatch.ts
+++ b/src/menu/actions/dispatch.ts
@@ -1,0 +1,23 @@
+import { scrollToId } from "../scroll/scrollToId";
+import type { ExternalActionMap, MenuAction } from "./types";
+
+/**
+ * Exécute une MenuAction.
+ */
+export function dispatch(action: MenuAction, external: ExternalActionMap): void {
+    switch (action.kind) {
+        case "href":
+            window.location.assign(action.href);
+            break;
+        case "hash":
+            scrollToId(action.targetId);
+            break;
+        case "externalClick":
+            external[action.handlerId]?.();
+            break;
+        case "toggle":
+        default:
+            // La logique de toggle est gérée par le code legacy
+            break;
+    }
+}

--- a/src/menu/actions/externalActions.ts
+++ b/src/menu/actions/externalActions.ts
@@ -1,0 +1,6 @@
+import type { ExternalActionMap } from "./types";
+
+/**
+ * Map des actions externes, à compléter selon les besoins du projet.
+ */
+export const externalActions: ExternalActionMap = {};

--- a/src/menu/actions/types.ts
+++ b/src/menu/actions/types.ts
@@ -1,0 +1,23 @@
+export type ToggleAction = {
+    kind: "toggle";
+    itemId: string;
+};
+
+export type HrefAction = {
+    kind: "href";
+    href: string;
+};
+
+export type HashAction = {
+    kind: "hash";
+    targetId: string;
+};
+
+export type ExternalClickAction = {
+    kind: "externalClick";
+    handlerId: string;
+};
+
+export type MenuAction = ToggleAction | HrefAction | HashAction | ExternalClickAction;
+
+export type ExternalActionMap = Record<string, () => void>;

--- a/src/menu/scroll/scrollToId.ts
+++ b/src/menu/scroll/scrollToId.ts
@@ -1,0 +1,15 @@
+/**
+ * Fait défiler la page jusqu'à l'élément correspondant à l'ID fourni.
+ * Applique le focus sur l'élément une fois le scroll effectué.
+ */
+export function scrollToId(id: string, offset = 0): void {
+    const el = document.getElementById(id);
+    if (!el) return;
+
+    const top = el.getBoundingClientRect().top + window.scrollY - offset;
+    window.scrollTo({ top, behavior: "smooth" });
+
+    if (el instanceof HTMLElement) {
+        el.focus();
+    }
+}

--- a/src/menu/scroll/useHashScroll.ts
+++ b/src/menu/scroll/useHashScroll.ts
@@ -1,0 +1,22 @@
+import { useEffect } from "react";
+import { scrollToId } from "./scrollToId";
+
+/**
+ * Hook déclenchant un scroll vers l'ancre courante et suivant les changements de hash.
+ */
+export function useHashScroll(offset = 0): void {
+    useEffect(() => {
+        const handle = () => {
+            const hash = window.location.hash.replace(/^#/, "");
+            if (hash) scrollToId(hash, offset);
+        };
+
+        handle();
+        window.addEventListener("hashchange", handle);
+        window.addEventListener("popstate", handle);
+        return () => {
+            window.removeEventListener("hashchange", handle);
+            window.removeEventListener("popstate", handle);
+        };
+    }, [offset]);
+}

--- a/src/menu/state/modes.ts
+++ b/src/menu/state/modes.ts
@@ -1,0 +1,2 @@
+export const modes = ["mobile", "tablet", "desktopReduced", "desktop"] as const;
+export type MenuMode = (typeof modes)[number];


### PR DESCRIPTION
## Description
- initialise les modules de menu (actions, scroll, state, a11y)
- ajoute le mapping MenuItem -> MenuAction et le dispatcher associé
- fournit des helpers de défilement et modes d'état

## Tests effectués
- `yarn install` (échoue : RequestError 403)
- `yarn lint`
- `yarn test` (échoue : vitest introuvable)


------
https://chatgpt.com/codex/tasks/task_e_68af5cb6c58483249c5f0a0daa04308b