### PR TITLE
[Feat] documenter questions ouvertes du menu

### DIFF
--- a/docs/audit/menu-open-questions.md
+++ b/docs/audit/menu-open-questions.md
@@ -1,0 +1,26 @@
+⚠️ **Note** — Document à valider avant implémentation.
+
+# ❓ Audit — Menu : questions ouvertes
+
+## 1) États finaux du réducteur
+
+| état             | largeur (px) | déclencheur cible               |
+| ---------------- | -----------: | ------------------------------- |
+| `mobile`         |        <1024 | navigation réduite              |
+| `tablet`         |    1024–1169 | apparition du bouton principal  |
+| `desktopReduced` |    1170–1439 | menu élargi sans tous les liens |
+| `desktop`        |        ≥1440 | menu complet                    |
+
+> Confirmer les valeurs exactes et les seuils de transition.
+
+## 2) Source de l’offset
+
+- `headerRef.current?.offsetHeight` (valeur runtime).
+- variable CSS `--header-h` synchronisée.
+- Besoin d’une fonction unique `getOffset()` pour le service de scroll.
+
+## 3) Items sans `path` / `AnchorId` / `subItems`
+
+- Traitement par défaut : `toggle` (aucune navigation).
+- Envisager un log d’avertissement pour audit.
+- Vérifier que ces items sont documentés dans `menuItems.ts`.


### PR DESCRIPTION
## Description
- ajout du document d'audit `docs/audit/menu-open-questions.md` listant les états finaux du réducteur, la source de l’offset et la stratégie pour les items sans `path`/`AnchorId`/`subItems`.

## Tests effectués
- `yarn install` (RequestError: Bad response 403)
- `yarn lint`
- `yarn test` (command not found: vitest)


------
https://chatgpt.com/codex/tasks/task_e_68af613b309083249c931d99f4c279a0