### PR TITLE
[Feat] fermeture du sous-menu via Échap

### DIFF
--- a/src/components/header/navLink/NavLinkShow.tsx
+++ b/src/components/header/navLink/NavLinkShow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useRef } from "react";
 import { MenuItem } from "@assets/data/menuItems";
 import SubMenu from "./SubMenu";
 import RenderLink from "./RenderLink";
@@ -30,10 +30,16 @@ const NavLinkShow: React.FC<NavLinkShowProps> = ({
     onMouseEnter,
     onFocus,
 }) => {
+    const triggerRef = useRef<HTMLDivElement>(null);
     const mainNav = !openMainButton && showNavLinks && !openButton;
     const renderSubMenu = () => {
         return menuItem.subItems && menuItem.subItems.length > 0 ? (
-            <SubMenu menuItem={menuItem} isOpen={isOpen} onSubItemClick={onNavigationClick} />
+            <SubMenu
+                menuItem={menuItem}
+                isOpen={isOpen}
+                onSubItemClick={onNavigationClick}
+                triggerRef={triggerRef}
+            />
         ) : null;
     };
     const handleInteraction = (event: React.MouseEvent | React.KeyboardEvent) => {
@@ -55,12 +61,13 @@ const NavLinkShow: React.FC<NavLinkShowProps> = ({
         </div>
     ) : (
         <div
+            ref={triggerRef}
             className={getShowGroupClass(menuItem.id, showNavLinks)}
             role="button"
             aria-label={`ouvrir le menu ${menuItem.title}`}
             aria-haspopup="menu"
-            aria-expanded={isOpen}
-            aria-controls={`sub-${menuItem.id}`}
+            aria-expanded={menuItem.subItems ? isOpen : undefined}
+            aria-controls={menuItem.subItems ? `sub-${menuItem.id}` : undefined}
             tabIndex={0}
             onClick={handleInteraction}
             onKeyDown={(e) => {

--- a/src/components/header/navLink/SubMenu.tsx
+++ b/src/components/header/navLink/SubMenu.tsx
@@ -8,33 +8,42 @@ interface SubMenuProps {
     menuItem: MenuItem;
     isOpen: boolean;
     onSubItemClick: (path: string) => void;
+    triggerRef: React.RefObject<HTMLElement>;
 }
 
-const SubMenu: React.FC<SubMenuProps> = ({ menuItem, isOpen, onSubItemClick }) => {
+const SubMenu: React.FC<SubMenuProps> = ({ menuItem, isOpen, onSubItemClick, triggerRef }) => {
     const { setOpenSubMenu } = useNavigation();
+
+    const closeSubMenu = () => {
+        setOpenSubMenu(null);
+        triggerRef.current?.focus();
+    };
+
     const handleSubItemClick = (path: string, e: React.MouseEvent | React.KeyboardEvent) => {
         e.preventDefault(); // Empêche la navigation par défaut
         onSubItemClick(path); // Appelle la fonction pour gérer le clic
-        setOpenSubMenu(null);
+        closeSubMenu();
     };
 
-    const handleKeyDown = (path: string, e: React.KeyboardEvent<HTMLElement>) => {
-        if (["Enter", " "].includes(e.key)) {
-            e.preventDefault(); // Empêche l'action par défaut de la touche
-            onSubItemClick(path); // Ouvre ou effectue une action pour le sous-menu
+    const handleKeyDown = (path: string | null, e: React.KeyboardEvent<HTMLElement>) => {
+        if (["Enter", " "].includes(e.key) && path) {
+            handleSubItemClick(path, e);
+        } else if (e.key === "Escape") {
+            e.preventDefault(); // Empêcher le comportement par défaut
+            closeSubMenu(); // Fermer le menu si Escape est pressé
         }
-        // else if (e.key === "Escape") {
-        //     e.preventDefault(); // Empêcher le comportement par défaut
-        //     setOpenSubMenu(null); // Fermer le menu si Escape est pressé
-        // }
     };
 
     if (!menuItem.subItems || menuItem.subItems.length === 0) return null;
 
     return (
-        // isOpen && (
         <div className={`submenu ${isOpen ? "open" : ""}`}>
-            <div className="submenu_group" role="menu" id={`sub-${menuItem.id}`}>
+            <div
+                className="submenu_group"
+                role="menu"
+                id={`sub-${menuItem.id}`}
+                onKeyDown={(e) => handleKeyDown(null, e)}
+            >
                 {menuItem.subItems.map((subItem) => {
                     const fullPath = `${menuItem.path}${subItem.AnchorId}`;
                     return (
@@ -53,7 +62,6 @@ const SubMenu: React.FC<SubMenuProps> = ({ menuItem, isOpen, onSubItemClick }) =
                 })}
             </div>
         </div>
-        // )
     );
 };
 


### PR DESCRIPTION
## Description
- fermeture du sous-menu avec la touche Escape
- rétablissement du focus sur le déclencheur
- liaison `aria-expanded`/`aria-controls` sur le bouton de menu

## Tests effectués
- `yarn lint` (warnings)
- `yarn test` *(échec : vitest absent)*

------
https://chatgpt.com/codex/tasks/task_e_68af62a7bcd08324be76dbeda617d191