### PR TITLE
[Feat] accessibilité du menu au clavier

### DIFF
--- a/__tests__/navlink.accessibility.test.tsx
+++ b/__tests__/navlink.accessibility.test.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { vi } from "vitest";
+import NavLinkShow from "@/components/header/navLink/NavLinkShow";
+import { NavigationProvider } from "@/utils/context/NavigationContext";
+import type { MenuItem } from "@assets/data/interfaces/menu";
+
+// Mock next/navigation used in NavigationProvider
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ push: vi.fn() }),
+    usePathname: () => "/",
+}));
+
+const menuItem: MenuItem = {
+    id: "test",
+    title: "Test",
+    class: "",
+    path: "/test",
+    svg: "Home",
+    AnchorId: "",
+    subItems: [{ id: "sub1", title: "Sub 1", AnchorId: "#sub1", class: "" }],
+};
+
+const renderComponent = (props: Partial<React.ComponentProps<typeof NavLinkShow>> = {}) => {
+    const defaultProps = {
+        menuItem,
+        onNavigationClick: vi.fn(),
+        isOpen: false,
+        showNavLinks: false,
+        handleMenuClick: vi.fn(),
+        onMenuToggle: vi.fn(),
+        openButton: true,
+        openMainButton: false,
+        onMouseEnter: vi.fn(),
+        onFocus: vi.fn(),
+        ...props,
+    };
+
+    return render(
+        <NavigationProvider>
+            <NavLinkShow {...defaultProps} />
+        </NavigationProvider>
+    );
+};
+
+describe("NavLinkShow — navigation clavier", () => {
+    const modes = [
+        { name: "mobile", width: 480 },
+        { name: "tablet", width: 1100 },
+        { name: "desktopReduced", width: 1300 },
+        { name: "desktop", width: 1500 },
+    ];
+
+    modes.forEach(({ name, width }) => {
+        test(`Enter déclenche onMenuToggle en mode ${name}`, () => {
+            Object.defineProperty(window, "innerWidth", { writable: true, value: width });
+            const onMenuToggle = vi.fn();
+            renderComponent({ onMenuToggle });
+            const wrapper = screen.getByRole("menuitem");
+            fireEvent.keyDown(wrapper, { key: "Enter" });
+            expect(onMenuToggle).toHaveBeenCalledWith(menuItem.id, expect.anything());
+        });
+    });
+
+    test("met à jour aria-expanded selon l'état", () => {
+        const { rerender } = renderComponent({ isOpen: false });
+        let wrapper = screen.getByRole("menuitem");
+        expect(wrapper).toHaveAttribute("aria-expanded", "false");
+
+        rerender(
+            <NavigationProvider>
+                <NavLinkShow
+                    menuItem={menuItem}
+                    onNavigationClick={vi.fn()}
+                    isOpen={true}
+                    showNavLinks={true}
+                    handleMenuClick={vi.fn()}
+                    onMenuToggle={vi.fn()}
+                    openButton={false}
+                    openMainButton={true}
+                    onMouseEnter={vi.fn()}
+                    onFocus={vi.fn()}
+                />
+            </NavigationProvider>
+        );
+        wrapper = screen.getByRole("menuitem");
+        expect(wrapper).toHaveAttribute("aria-expanded", "true");
+    });
+});

--- a/src/components/header/navInput/NavInput.tsx
+++ b/src/components/header/navInput/NavInput.tsx
@@ -44,6 +44,7 @@ const NavInput: React.FC<NavInputProps> = ({
         }
     };
 
+    const submenuId = `sub-${menuItem.id}`;
     const renderSubResult = () =>
         showNavLinks &&
         isSubResultOpen &&
@@ -52,6 +53,7 @@ const NavInput: React.FC<NavInputProps> = ({
                 suggestions={suggestions}
                 isOpen={isOpen}
                 onSuggestionClick={handleSuggestionClick}
+                id={submenuId}
             />
         );
 
@@ -60,6 +62,9 @@ const NavInput: React.FC<NavInputProps> = ({
             className={getShowGroupClass(menuItem.id, showNavLinks)}
             role="menuitem"
             aria-label={`ouvrir le menu ${menuItem.title}`}
+            aria-haspopup="true"
+            aria-expanded={isOpen}
+            aria-controls={submenuId}
             tabIndex={0}
             onClick={(e) => onMenuToggle(menuItem.id, e)}
             onKeyDown={handleKeyDown}

--- a/src/components/header/navInput/SubResult.tsx
+++ b/src/components/header/navInput/SubResult.tsx
@@ -4,18 +4,15 @@ interface SubResultProps {
     suggestions: string[];
     isOpen: boolean;
     onSuggestionClick: (suggestion: string) => void;
+    id: string;
 }
 
-const SubResult: React.FC<SubResultProps> = ({
-    suggestions,
-    isOpen,
-    onSuggestionClick,
-}) => {
+const SubResult: React.FC<SubResultProps> = ({ suggestions, isOpen, onSuggestionClick, id }) => {
     if (!suggestions || suggestions.length === 0) return null;
 
     return (
         <div className={`submenu ${isOpen ? "open" : ""}`}>
-            <div className="submenu_group">
+            <div className="submenu_group" role="menu" id={id}>
                 {suggestions.map((suggestion) => (
                     <option
                         key={suggestion}

--- a/src/components/header/navLink/NavLinkShow.tsx
+++ b/src/components/header/navLink/NavLinkShow.tsx
@@ -50,6 +50,10 @@ const NavLinkShow: React.FC<NavLinkShowProps> = ({
     return openMainButton || mainNav || (openButton && showNavLinks) ? (
         <div
             className={`group_link-submenu ${menuItem.id} ${!openMainButton ? "nav-padding" : ""}`}
+            role="menuitem"
+            aria-haspopup={menuItem.subItems ? "true" : undefined}
+            aria-expanded={menuItem.subItems ? isOpen : undefined}
+            aria-controls={menuItem.subItems ? `sub-${menuItem.id}` : undefined}
         >
             <RenderLink
                 menuItem={menuItem}
@@ -63,9 +67,9 @@ const NavLinkShow: React.FC<NavLinkShowProps> = ({
         <div
             ref={triggerRef}
             className={getShowGroupClass(menuItem.id, showNavLinks)}
-            role="button"
+            role="menuitem"
             aria-label={`ouvrir le menu ${menuItem.title}`}
-            aria-haspopup="menu"
+            aria-haspopup={menuItem.subItems ? "true" : undefined}
             aria-expanded={menuItem.subItems ? isOpen : undefined}
             aria-controls={menuItem.subItems ? `sub-${menuItem.id}` : undefined}
             tabIndex={0}


### PR DESCRIPTION
## Description
- ajoute `role="menuitem"` et les attributs ARIA au wrapper des entrées de menu
- couvre la navigation clavier sur les différents modes d'affichage

## Tests effectués
- `yarn install` *(échoué: RequestError 403)*
- `yarn lint`
- `yarn test` *(échoué: command not found: vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68afff8fc4a883249d70d2260da7d0f6