### PR TITLE
[Feat] scroll offset with header height

### DIFF
--- a/src/menu/actions/dispatch.ts
+++ b/src/menu/actions/dispatch.ts
@@ -1,16 +1,20 @@
-import { scrollToId } from "../scroll/scrollToId";
+import { scrollToId, getHeaderOffset } from "../scroll/scrollToId";
 import type { ExternalActionMap, MenuAction } from "./types";
 
 /**
  * Exécute une MenuAction.
  */
-export function dispatch(action: MenuAction, external: ExternalActionMap): void {
+export function dispatch(
+    action: MenuAction,
+    external: ExternalActionMap,
+    offset: number = getHeaderOffset()
+): void {
     switch (action.kind) {
         case "href":
             window.location.assign(action.href);
             break;
         case "hash":
-            scrollToId(action.targetId);
+            scrollToId(action.targetId, offset);
             break;
         case "externalClick":
             external[action.handlerId]?.();

--- a/src/menu/scroll/scrollToId.ts
+++ b/src/menu/scroll/scrollToId.ts
@@ -1,8 +1,16 @@
 /**
- * Fait défiler la page jusqu'à l'élément correspondant à l'ID fourni.
- * Applique le focus sur l'élément une fois le scroll effectué.
+ * Calcule la hauteur du header pour définir l'offset par défaut.
  */
-export function scrollToId(id: string, offset = 0): void {
+export function getHeaderOffset(): number {
+    const header = document.querySelector("header");
+    return header instanceof HTMLElement ? header.offsetHeight : 0;
+}
+
+/**
+ * Fait défiler la page jusqu'à l'élément correspondant à l'ID fourni.
+ * Soustrait la hauteur du header (offset) puis applique le focus.
+ */
+export function scrollToId(id: string, offset: number = getHeaderOffset()): void {
     const el = document.getElementById(id);
     if (!el) return;
 

--- a/src/menu/scroll/useHashScroll.ts
+++ b/src/menu/scroll/useHashScroll.ts
@@ -1,10 +1,10 @@
 import { useEffect } from "react";
-import { scrollToId } from "./scrollToId";
+import { scrollToId, getHeaderOffset } from "./scrollToId";
 
 /**
  * Hook déclenchant un scroll vers l'ancre courante et suivant les changements de hash.
  */
-export function useHashScroll(offset = 0): void {
+export function useHashScroll(offset: number = getHeaderOffset()): void {
     useEffect(() => {
         const handle = () => {
             const hash = window.location.hash.replace(/^#/, "");


### PR DESCRIPTION
## Description
- calcule la hauteur du header et applique l'offset lors du scroll vers une ancre
- rend l'offset configurable dans le dispatcher

## Tests effectués
- `yarn lint`
- `yarn test` *(échoué : `vitest` introuvable)*


------
https://chatgpt.com/codex/tasks/task_e_68afffa843448324a3c0d0f76088c517