### PR TITLE
[Feat] ajout du script de tests API

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
         "generate:sitemap": "node scripts/generate-sitemap.js",
         "test:unit": "vitest run --coverage",
         "test:e2e": "playwright test",
-        "test": "npm run test:unit && npm run test:e2e",
-        "test:watch": "vitest"
+        "test": "npm run test:unit && npm run test:api && npm run test:e2e",
+        "test:watch": "vitest",
+        "test:api": "vitest run tests/api --coverage"
     },
     "dependencies": {
         "@aws-amplify/auth": "^6.13.0",


### PR DESCRIPTION
## Description
- ajoute le script `test:api` pour exécuter les tests d'API avec couverture
- met à jour le script `test` pour lancer `test:unit`, `test:api` et `test:e2e`

## Tests effectués
- `yarn install` *(échec : Bad response 403)*
- `npm run test:unit` *(échec : vitest not found)*
- `npm run test:api` *(échec : vitest not found)*
- `npm run test:e2e` *(échec : playwright not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b018c64f648324be02c0bff31efd15