### PR TITLE
[Fix] configure public npm registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,2 @@
 nodeLinker: node-modules
+npmRegistryServer: "https://registry.npmjs.org"


### PR DESCRIPTION
## Description
- enforce public registry via `npmRegistryServer`
- add `.npmrc` with `NPM_TOKEN` placeholder

## Tests effectués
- `yarn install` (échec 403)
- `yarn lint`
- `yarn test` (commande introuvable)


------
https://chatgpt.com/codex/tasks/task_e_68b01cb2c38c8324acb0761131e00859