### PR TITLE
[Feat] ajout d’un script de vérification de types

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "start": "next start",
         "lint": "next lint",
         "generate:sitemap": "node scripts/generate-sitemap.js",
+        "type-check": "tsc --noEmit",
         "test:unit": "vitest",
         "test:e2e": "playwright test",
         "test": "vitest run",


### PR DESCRIPTION
## Description
- ajoute le script `type-check` pour exécuter `tsc --noEmit`

## Tests effectués
- `yarn install` *(échec : RequestError 403)*
- `yarn lint`
- `yarn test` *(échec : command not found: vitest)*
- `yarn type-check` *(échec : erreurs de compilation TypeScript)*

------
https://chatgpt.com/codex/tasks/task_e_68b02009a2048324925c6d8fefba94ad