### PR TITLE
[Fix] déplacer @aws-amplify/cli en devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     },
     "dependencies": {
         "@aws-amplify/auth": "^6.13.0",
-        "@aws-amplify/cli": "^13.0.1",
         "@aws-amplify/core": "^6.11.4",
         "@aws-amplify/ui-react": "^6.11.1",
         "@aws-sdk/client-cognito-identity-provider": "^3.806.0",
@@ -40,6 +39,7 @@
     "devDependencies": {
         "@aws-amplify/backend": "^1.5.1",
         "@aws-amplify/backend-cli": "^1.3.0",
+        "@aws-amplify/cli": "^13.0.1",
         "@testing-library/jest-dom": "^6.4.1",
         "@testing-library/react": "^16.0.0",
         "@types/node": "^20",


### PR DESCRIPTION
## Description
- move `@aws-amplify/cli` from dependencies to devDependencies
- attempted `yarn install` but it fails with 403 (missing `NPM_TOKEN`)

## Tests effectués
- `yarn lint` *(warnings seulement)*
- `yarn test` *(échoué : `vitest` absent car `yarn install` échoue)*
- `yarn install` *(échoué : 403 du registre)*


------
https://chatgpt.com/codex/tasks/task_e_68b0203defe08324af710084fd51a85a