### PR TITLE
[Fix] vérifie navRef dans handleClickOutside

### DIFF
--- a/src/utils/updateMenuUtils.ts
+++ b/src/utils/updateMenuUtils.ts
@@ -75,10 +75,14 @@ export const resetActiveMenuClasses = () => {
 
 const handleClickOutside = (
     e: MouseEvent,
-    navRef: React.RefObject<HTMLElement>,
+    navRef: React.RefObject<HTMLElement | null>,
     setOpenSubMenu: React.Dispatch<React.SetStateAction<string | null>>
 ) => {
-    if (navRef.current && !navRef.current.contains(e.target as Node)) {
+    if (!navRef.current) {
+        return;
+    }
+
+    if (!navRef.current.contains(e.target as Node)) {
         setOpenSubMenu(null);
     }
 };


### PR DESCRIPTION
### Description
- sécurise `handleClickOutside` en vérifiant `navRef.current` avant usage

### Tests effectués
- `yarn lint` *(échec : Definition for rule '@typescript-eslint/no-unused-vars' was not found)*
- `yarn tsc --noEmit` *(échec : Property 'saveField' does not exist on type ...)*
- `yarn test` *(échec : Failed to load url @entities/models/section/service)*

------
https://chatgpt.com/codex/tasks/task_e_68b0770f69208324897da01b0e9dd616