### PR TITLE
[Fix] rendre triggerRef optionnel

### DIFF
--- a/src/components/header/navLink/SubMenu.tsx
+++ b/src/components/header/navLink/SubMenu.tsx
@@ -8,7 +8,7 @@ interface SubMenuProps {
     menuItem: MenuItem;
     isOpen: boolean;
     onSubItemClick: (path: string, scrollOffset?: number) => void;
-    triggerRef: React.RefObject<HTMLElement>;
+    triggerRef?: React.RefObject<HTMLDivElement | null>;
 }
 
 const SubMenu: React.FC<SubMenuProps> = ({ menuItem, isOpen, onSubItemClick, triggerRef }) => {
@@ -16,7 +16,7 @@ const SubMenu: React.FC<SubMenuProps> = ({ menuItem, isOpen, onSubItemClick, tri
 
     const closeSubMenu = () => {
         setOpenSubMenu(null);
-        triggerRef.current?.focus();
+        triggerRef?.current?.focus();
     };
 
     const handleSubItemClick = (path: string, e: React.MouseEvent | React.KeyboardEvent) => {


### PR DESCRIPTION
## Description
- rendre `triggerRef` optionnel et utiliser un `RefObject<HTMLDivElement | null>`

## Tests effectués
- `yarn prettier src/components/header/navLink/SubMenu.tsx src/components/header/navLink/NavLinkShow.tsx --write`
- `yarn lint` *(échec : processus bloqué)*
- `yarn build` *(échec : interrompu)*
- `yarn test` *(échec : modules manquants)*
- `yarn tsc --noEmit` *(échec : erreurs de typage existantes)*

------
https://chatgpt.com/codex/tasks/task_e_68b0770b4aa08324898bc190b4b67c96