### PR TITLE
Fix: make triggerRef optional in SubMenu

### DIFF
--- a/src/components/header/navLink/SubMenu.tsx
+++ b/src/components/header/navLink/SubMenu.tsx
@@ -8,7 +8,7 @@ interface SubMenuProps {
     menuItem: MenuItem;
     isOpen: boolean;
     onSubItemClick: (path: string, scrollOffset?: number) => void;
-    triggerRef: React.RefObject<HTMLElement>;
+    triggerRef?: React.RefObject<HTMLElement | null>;
 }
 
 const SubMenu: React.FC<SubMenuProps> = ({ menuItem, isOpen, onSubItemClick, triggerRef }) => {
@@ -16,7 +16,9 @@ const SubMenu: React.FC<SubMenuProps> = ({ menuItem, isOpen, onSubItemClick, tri
 
     const closeSubMenu = () => {
         setOpenSubMenu(null);
-        triggerRef.current?.focus();
+        if (triggerRef?.current) {
+            triggerRef.current.focus();
+        }
     };
 
     const handleSubItemClick = (path: string, e: React.MouseEvent | React.KeyboardEvent) => {


### PR DESCRIPTION
## Summary
- allow SubMenu to accept optional triggerRef and guard focus usage

## Testing
- `yarn install`
- `yarn prettier src/components/header/navLink/SubMenu.tsx --write`
- `yarn lint` *(interrompu: aucune sortie)*
- `yarn build` *(échoué: module introuvable `@/amplify_outputs.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68b0770a813883249f6298fac7584553