### PR TITLE
[Fix] Vérifier l'ID utilisateur avant création de pseudo

### DIFF
--- a/src/app/Authentication/Authentication.tsx
+++ b/src/app/Authentication/Authentication.tsx
@@ -15,6 +15,7 @@ export default function Authentication() {
         async handleSignUp(formData: Parameters<typeof signUp>[0]) {
             const result = await signUp(formData);
             try {
+                if (!result.userId) throw new Error("User ID manquant");
                 await userNameService.create({
                     id: result.userId,
                     userName: formData.username,


### PR DESCRIPTION
## Description
- s'assure que `result.userId` est présent avant l'appel à `userNameService.create`

## Tests effectués
- `yarn lint` (erreurs existantes dans le dépôt)
- `yarn tsc --noEmit` (erreurs TypeScript existantes)


------
https://chatgpt.com/codex/tasks/task_e_68b07709bae08324b32657ff275f5c3b