### PR TITLE
[Fix] autoriser useUserNameForm sans argument

### DIFF
--- a/src/entities/models/userName/hooks.tsx
+++ b/src/entities/models/userName/hooks.tsx
@@ -14,7 +14,7 @@ import { emitUserNameUpdated } from "./bus";
 
 type Extras = { userNames: UserNameType[] };
 
-export function useUserNameForm(userName: UserNameType | null) {
+export function useUserNameForm(userName: UserNameType | null = null) {
     const { user } = useAuthenticator();
     const sub = user?.userId ?? user?.username ?? null;
 


### PR DESCRIPTION
## Description
- accepte `null` par défaut dans `useUserNameForm`

## Tests effectués
- `yarn lint` (erreurs : @typescript-eslint/no-unused-vars manquant, internal/no-onclick-wrapper...)
- `yarn build` (échec : module '@/amplify_outputs.json' introuvable)
- `yarn tsc --noEmit` (échec : plusieurs erreurs de typage)


------
https://chatgpt.com/codex/tasks/task_e_68b077084b948324948be6a2ba04930f