### PR TITLE
[Feat] résolution de l'offset de défilement

### DIFF
--- a/src/menu/scroll/resolveScrollOffset.ts
+++ b/src/menu/scroll/resolveScrollOffset.ts
@@ -1,0 +1,12 @@
+/**
+ * Résout l'offset de défilement à appliquer.
+ * Si un offset est fourni, il est retourné directement.
+ * Sinon, la hauteur de l'en-tête (classe `.header`) est utilisée si disponible.
+ */
+export function resolveScrollOffset(offset?: number): number {
+    if (typeof offset === "number") {
+        return offset;
+    }
+    const header = document.querySelector<HTMLElement>(".header");
+    return header ? header.offsetHeight : 0;
+}


### PR DESCRIPTION
## Description
- ajout d'une fonction utilitaire `resolveScrollOffset` pour déterminer l'offset de défilement à partir d'un paramètre ou de la hauteur de l'en-tête

## Tests effectués
- `yarn install`
- `yarn prettier --write src/menu/scroll/resolveScrollOffset.ts`
- `yarn lint` *(en erreur)*
- `yarn test:unit` *(en erreur)*
- `yarn test:api` *(aucun test)*
- `yarn test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68b09593bbec8324b807c000c35aa5e9