### PR TITLE
[Fix] document test directories and Amplify mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 ## Tests
 
+La suite de tests est organisée par type :
+
+- `tests/unit` : tests unitaires
+- `tests/api` : tests des API
+- `tests/e2e` : tests end‑to‑end (Playwright)
+- `tests/_legacy` : anciens tests conservés à titre de référence
+
 ### Installation
 
 ```bash
@@ -75,5 +82,5 @@ yarn install
 
 ### Mock d'AWS Amplify
 
-Le mock d'AWS Amplify et la configuration partagée se trouvent dans `tests/_legacy/setupTests.ts`.
+Le mock d'AWS Amplify et la configuration partagée se trouvent dans `tests/setupTests.ts`.
 Ce fichier configure Amplify et le serveur MSW avant chaque test.

--- a/tests/_legacy/setupTests.ts
+++ b/tests/_legacy/setupTests.ts
@@ -1,16 +1,5 @@
-import "tsconfig-paths/register";
-import { Amplify } from "aws-amplify";
-import { beforeAll, afterEach, afterAll } from "vitest";
-import { setupServer } from "msw/node";
-import outputs from "@/amplify_outputs.json";
-import "@testing-library/jest-dom/vitest";
-import "whatwg-fetch";
-
-export const server = setupServer();
-
-beforeAll(() => {
-    Amplify.configure(outputs);
-    server.listen();
-});
-afterEach(() => server.resetHandlers());
-afterAll(() => server.close());
+/**
+ * Fichier de compatibilité pour les anciens tests.
+ * Réexporte la configuration du mock AWS Amplify depuis `tests/setupTests.ts`.
+ */
+export { server } from "../setupTests";

--- a/tests/setupTests.ts
+++ b/tests/setupTests.ts
@@ -1,0 +1,20 @@
+import "tsconfig-paths/register";
+import { Amplify } from "aws-amplify";
+import { beforeAll, afterEach, afterAll } from "vitest";
+import { setupServer } from "msw/node";
+import outputs from "@/amplify_outputs.json";
+import "@testing-library/jest-dom/vitest";
+import "whatwg-fetch";
+
+/**
+ * Initialisation du mock AWS Amplify et du serveur MSW pour l'ensemble des tests.
+ * Ce fichier configure Amplify avec les sorties locales et démarre MSW pour intercepter les requêtes réseau.
+ */
+export const server = setupServer();
+
+beforeAll(() => {
+    Amplify.configure(outputs);
+    server.listen();
+});
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,8 +22,7 @@ export default defineConfig({
     },
     test: {
         environment: "jsdom",
-        setupFiles: ["./tests/_legacy/setupTests.ts"],
+        setupFiles: ["./tests/setupTests.ts"],
         exclude: ["**/node_modules/**", "tests/e2e/**"],
     },
 });
-


### PR DESCRIPTION
## Summary
- clarify test folder structure and commands in docs
- centralize AWS Amplify mock in tests/setupTests.ts
- point Vitest to the new setup file

## Testing
- `yarn lint`
- `yarn test:unit`
- `yarn test:api`
- `yarn test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68b096e8e2d48324a82c64f52f5697c1