### PR TITLE
[Fix] harmoniser scripts de test

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ yarn install
 
 ### Exécution
 
-- `yarn test` – lance l'ensemble de la suite de tests.
+- `yarn test` – exécute successivement `yarn test:unit`, `yarn test:api` puis `yarn test:e2e`.
 - `yarn test:unit` – exécute les tests unitaires (`tests/unit`).
 - `yarn test:api` – exécute les tests d'API (`tests/api`).
 - `yarn test:e2e` – exécute les tests end-to-end avec Playwright (`tests/e2e`).

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
         "gen:entities": "tsx scripts/generator/entry.ts",
         "gen:entities:debug": "tsx scripts/generator/entry.ts --debug",
         "test": "yarn test:unit && yarn test:api && yarn test:e2e",
-        "test:unit": "vitest run tests/unit --coverage",
-        "test:api": "vitest run tests/api --coverage",
+        "test:unit": "vitest run ./tests/unit --coverage",
+        "test:api": "vitest run ./tests/api --coverage",
         "test:e2e": "playwright test",
         "generate:sitemap": "node scripts/generate-sitemap.js"
     },


### PR DESCRIPTION
## Description
- préciser les chemins des tests dans les scripts
- documenter l'enchaînement des tests dans le README

## Tests effectués
- `yarn lint` *(échecs : règles manquantes et no-onclick-wrapper)*
- `yarn test` *(échecs : `menu.legacy.integration.test.tsx`, `syncManyToMany.test.ts`)*

------
https://chatgpt.com/codex/tasks/task_e_68b096f055dc8324a733707dd3147938