### PR TITLE
[Feat] ajout d'un test API minimal

### DIFF
--- a/tests/api/example.api.test.ts
+++ b/tests/api/example.api.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { Amplify } from "aws-amplify";
+import { server } from "@test/setupTests";
+import { http, HttpResponse } from "msw";
+
+/**
+ * Test d'exemple validant la configuration de MSW et d'AWS Amplify.
+ */
+describe("exemple d'API", () => {
+    it("AWS Amplify est configuré", () => {
+        expect(typeof Amplify.configure).toBe("function");
+    });
+
+    it("répond via le mock MSW", async () => {
+        server.use(
+            http.get("https://example.com/hello", () => HttpResponse.json({ message: "salut" }))
+        );
+
+        const res = await fetch("https://example.com/hello");
+        const data = await res.json();
+
+        expect(data).toEqual({ message: "salut" });
+    });
+});


### PR DESCRIPTION
## Description
- ajoute un test API d'exemple utilisant Vitest, MSW et AWS Amplify

## Tests effectués
- `yarn lint` *(échoue: Definition for rule '@typescript-eslint/no-unused-vars' was not found)*
- `yarn test:api`


------
https://chatgpt.com/codex/tasks/task_e_68b099f51d5c8324b9d41f8c6e3df290