### PR TITLE
[Fix] calcul de l'offset initial de scroll

### DIFF
--- a/src/utils/scrollUtils.ts
+++ b/src/utils/scrollUtils.ts
@@ -2,6 +2,8 @@
 import { useEffect } from "react";
 import { useScrollContext } from "./context/ScrollContext";
 import { resetActiveMenuClasses } from "./updateMenuUtils";
+import { menuItems } from "@assets/data/menuItems";
+import { resolveScrollOffset } from "../menu/scroll/resolveScrollOffset";
 import {
     addNewUrl,
     updateSectionClasses,
@@ -14,7 +16,18 @@ export const useInitialScroll = (pathname: string | null) => {
     useEffect(() => {
         if (window.location.hash) {
             window.scrollTo({ top: 0 });
-            handleScrollClick(window.location.hash.substring(1));
+            const hashWithSharp = window.location.hash;
+            const hash = hashWithSharp.substring(1);
+            const allItems = [
+                ...menuItems.mainLink,
+                ...(menuItems.reservation ?? []),
+                ...(menuItems.search ?? []),
+                ...(menuItems.connection ?? []),
+            ];
+            const menuItem = allItems.find((item) => item.path === pathname);
+            const subItem = menuItem?.subItems?.find((s) => s.AnchorId === hashWithSharp);
+            const offset = resolveScrollOffset(menuItem, subItem);
+            handleScrollClick(hash, offset);
         }
         resetActiveMenuClasses();
     }, [pathname]);


### PR DESCRIPTION
## Description
- utilise `resolveScrollOffset` pour déterminer l'offset initial
- applique `handleScrollClick` avec l'offset calculé

## Tests effectués
- `yarn lint` *(échec : règles ESLint manquantes)*
- `yarn test:unit` *(échec : imports manquants pour les mocks Amplify)*
- `yarn test:integration` *(échec : doublons d'éléments rôle button)*
- `yarn test:e2e` *(échec : navigateurs Playwright non installés)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a2eaef3083249635ae0f4decf55c