### PR TITLE
[Fix] ajoute alias @test pour Vitest

### DIFF
--- a/tests/setupTests.ts
+++ b/tests/setupTests.ts
@@ -1,4 +1,3 @@
-import "tsconfig-paths/register";
 import { Amplify } from "aws-amplify";
 import { beforeAll, afterEach, afterAll } from "vitest";
 import { setupServer } from "msw/node";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
             "@myTypes": path.resolve(__dirname, "src/types"),
             "@entities": path.resolve(__dirname, "src/entities"),
             "@public": path.resolve(__dirname, "public"),
+            "@test": path.resolve(__dirname, "tests"),
             tests: path.resolve(__dirname, "tests"),
         },
     },


### PR DESCRIPTION
## Description
- ajoute l'alias `@test` dans la config Vitest
- supprime l'usage de `tsconfig-paths/register` dans les tests

## Tests effectués
- `yarn test:unit` *(échec : syncManyToMany > assertion)*
- `yarn test:api`
- `yarn test:integration` *(échec : menu legacy > getByRole)*
- `yarn test:e2e` *(échec : navigateurs Playwright manquants)*
- `npx eslint vitest.config.ts tests/setupTests.ts` *(échec : ESLint config manquante)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a2950aa883249a8bc877af1d570c