### PR TITLE
[Fix] corrige le calcul du scrollOffset des sous-liens

### DIFF
--- a/src/components/header/navLink/SubMenu.tsx
+++ b/src/components/header/navLink/SubMenu.tsx
@@ -9,7 +9,6 @@ interface SubMenuProps {
     isOpen: boolean;
     onSubItemClick: (path: string, scrollOffset?: number) => void;
     triggerRef?: React.RefObject<HTMLDivElement | HTMLElement | null>;
-
 }
 
 const SubMenu: React.FC<SubMenuProps> = ({ menuItem, isOpen, onSubItemClick, triggerRef }) => {
@@ -22,15 +21,24 @@ const SubMenu: React.FC<SubMenuProps> = ({ menuItem, isOpen, onSubItemClick, tri
         }
     };
 
-    const handleSubItemClick = (path: string, e: React.MouseEvent | React.KeyboardEvent) => {
+    const handleSubItemClick = (
+        path: string,
+        subItemScrollOffset: number | undefined,
+        e: React.MouseEvent | React.KeyboardEvent
+    ) => {
         e.preventDefault(); // Empêche la navigation par défaut
-        onSubItemClick(path, menuItem.scrollOffset); // Appelle la fonction pour gérer le clic
+        const offset = menuItem.scrollOffset ?? subItemScrollOffset;
+        onSubItemClick(path, offset); // Appelle la fonction pour gérer le clic
         closeSubMenu();
     };
 
-    const handleKeyDown = (path: string | null, e: React.KeyboardEvent<HTMLElement>) => {
+    const handleKeyDown = (
+        path: string | null,
+        subItemScrollOffset: number | undefined,
+        e: React.KeyboardEvent<HTMLElement>
+    ) => {
         if (["Enter", " "].includes(e.key) && path) {
-            handleSubItemClick(path, e);
+            handleSubItemClick(path, subItemScrollOffset, e);
         } else if (e.key === "Escape") {
             e.preventDefault(); // Empêcher le comportement par défaut
             closeSubMenu(); // Fermer le menu si Escape est pressé
@@ -45,7 +53,7 @@ const SubMenu: React.FC<SubMenuProps> = ({ menuItem, isOpen, onSubItemClick, tri
                 className="submenu_group"
                 role="menu"
                 id={`sub-${menuItem.id}`}
-                onKeyDown={(e) => handleKeyDown(null, e)}
+                onKeyDown={(e) => handleKeyDown(null, undefined, e)}
             >
                 {menuItem.subItems.map((subItem) => {
                     const fullPath = `${menuItem.path ?? ""}${subItem.AnchorId ?? ""}`;
@@ -56,8 +64,8 @@ const SubMenu: React.FC<SubMenuProps> = ({ menuItem, isOpen, onSubItemClick, tri
                             href={fullPath}
                             className={`nav-link ${subItem.class}`}
                             tabIndex={0}
-                            onClick={(e) => handleSubItemClick(fullPath, e)}
-                            onKeyDown={(e) => handleKeyDown(fullPath, e)}
+                            onClick={(e) => handleSubItemClick(fullPath, subItem.scrollOffset, e)}
+                            onKeyDown={(e) => handleKeyDown(fullPath, subItem.scrollOffset, e)}
                         >
                             {subItem.title}
                         </a>


### PR DESCRIPTION
## Description
- calcule le décalage en priorisant `menuItem.scrollOffset` puis `subItem.scrollOffset`
- propage `subItem.scrollOffset` aux gestionnaires `onClick` et `onKeyDown`

## Tests effectués
- `yarn install` *(échoue : @aws-sdk/types introuvable)*
- `yarn prettier --write src/components/header/navLink/SubMenu.tsx` *(échoue : état node_modules manquant)*
- `npx prettier --write src/components/header/navLink/SubMenu.tsx`
- `yarn lint` *(échoue : état node_modules manquant)*


------
https://chatgpt.com/codex/tasks/task_e_68b0a6bb6f70832496828e52cea7030f