### PR TITLE
[Fix] harmonisation des dépendances de test et des engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
         "@aws-amplify/cli": "^13.0.1",
         "@eslint/eslintrc": "^3",
         "@faker-js/faker": "^9.0.0",
+        "@playwright/test": "^1.48.2",
         "@rushstack/eslint-patch": "^1",
         "@tailwindcss/postcss": "^4",
         "@testing-library/dom": "^10.4.1",
@@ -103,7 +104,8 @@
     ],
     "packageManager": "yarn@4.9.4",
     "engines": {
-        "node": "20.18.x"
+        "node": ">=20.18.0",
+        "yarn": ">=4.0.0"
     },
     "packageExtensions": {
         "@aws-amplify/plugin-types@*": {


### PR DESCRIPTION
## Description
- ajoute `@playwright/test` aux `devDependencies`
- précise Node >= 20.18 et Yarn 4 dans `engines`

## Tests effectués
- `yarn install` *(échoue : @aws-sdk/types@npm:^3.876.0: No candidates found)*
- `yarn prettier package.json --write` *(échoue : Couldn't find the node_modules state file)*
- `yarn lint` *(échoue : Couldn't find the node_modules state file)*
- `yarn test:unit` *(échoue : Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a69f33908324b0edfc1586777703