### PR TITLE
[Feat] ajout retry scrollToId avec focus

### DIFF
--- a/src/menu/scroll/scrollToId.ts
+++ b/src/menu/scroll/scrollToId.ts
@@ -1,15 +1,26 @@
 /**
  * Fait défiler la page jusqu'à l'élément correspondant à l'ID fourni.
- * Applique le focus sur l'élément une fois le scroll effectué.
+ * Attendre la disponibilité de l'élément avec `requestAnimationFrame` avant de déclencher le scroll.
+ * Respecte `prefers-reduced-motion` et applique `focus({ preventScroll: true })`.
  */
 export function scrollToId(id: string, offset = 0): void {
-    const el = document.getElementById(id);
-    if (!el) return;
+    const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
-    const top = el.getBoundingClientRect().top + window.scrollY - offset;
-    window.scrollTo({ top, behavior: "smooth" });
+    function attempt(): void {
+        const el = document.getElementById(id);
+        if (!el) {
+            window.requestAnimationFrame(attempt);
+            return;
+        }
 
-    if (el instanceof HTMLElement) {
-        el.focus();
+        const top = el.getBoundingClientRect().top + window.scrollY - offset;
+        const behavior: ScrollBehavior = prefersReducedMotion ? "auto" : "smooth";
+        window.scrollTo({ top, behavior });
+
+        if (el instanceof HTMLElement) {
+            el.focus({ preventScroll: true });
+        }
     }
+
+    window.requestAnimationFrame(attempt);
 }

--- a/tests/unit/menu.scroll.test.ts
+++ b/tests/unit/menu.scroll.test.ts
@@ -1,25 +1,35 @@
 /**
- * ⚠️ Test d’exemple pour scrollToId. JSDOM ne fait pas défiler la page, on vérifie juste l’appel.
- * Adaptez l’import dès que `src/menu/scroll/scrollToId.ts` est présent.
+ * Tests pour `scrollToId`.
+ * JSDOM ne fait pas défiler la page, on vérifie l’appel et les options.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-// import { scrollToId } from '@/menu/scroll/scrollToId';
+import { scrollToId } from "@/menu/scroll/scrollToId";
 
-// Stub local (à supprimer quand vous importez le vrai scrollToId)
-function scrollToId(id: string, offset = 0) {
-    const el = document.getElementById(id);
-    if (!el) return;
-    const rectTop = el.getBoundingClientRect().top;
-    const top = rectTop + window.scrollY - offset;
-    window.scrollTo({ top, behavior: "smooth" });
-    (el as HTMLElement).focus?.({ preventScroll: true });
-}
+let focusMock: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
     document.body.innerHTML = `<div style="height:2000px"></div><section id="target" tabindex="-1">X</section>`;
+
+    // Mocks
     // @ts-expect-error: inject mock
     window.scrollTo = vi.fn();
+    window.requestAnimationFrame = vi.fn((cb: FrameRequestCallback) => {
+        cb(0);
+        return 0;
+    });
+    window.matchMedia = vi.fn().mockReturnValue({
+        matches: false,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+    });
+
+    focusMock = vi.fn();
+    HTMLElement.prototype.focus = focusMock;
+
     // JSDOM getBoundingClientRect default
     const target = document.getElementById("target")!;
     target.getBoundingClientRect = () => ({
@@ -35,13 +45,71 @@ beforeEach(() => {
             return {};
         },
     });
+
     // @ts-expect-error
     window.scrollY = 100;
 });
 
-describe("scrollToId (exemple)", () => {
+afterEach(() => {
+    vi.clearAllMocks();
+});
+
+describe("scrollToId", () => {
     it("défile jusqu’à la bonne position (offset pris en compte)", () => {
         scrollToId("target", 64);
-        expect(window.scrollTo).toHaveBeenCalledWith({ top: 300 + 100 - 64, behavior: "smooth" });
+        expect(window.scrollTo).toHaveBeenCalledWith({
+            top: 300 + 100 - 64,
+            behavior: "smooth",
+        });
+        expect(focusMock).toHaveBeenCalledWith({ preventScroll: true });
+    });
+
+    it("utilise 'auto' si prefers-reduced-motion", () => {
+        (window.matchMedia as any).mockReturnValue({
+            matches: true,
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+        });
+        scrollToId("target", 0);
+        expect(window.scrollTo).toHaveBeenCalledWith({ top: 300 + 100, behavior: "auto" });
+    });
+
+    it("réessaie jusqu’à trouver l’élément", () => {
+        document.body.innerHTML = ""; // élément absent initialement
+        const callbacks: FrameRequestCallback[] = [];
+        window.requestAnimationFrame = vi.fn((cb: FrameRequestCallback) => {
+            callbacks.push(cb);
+            return 0;
+        });
+
+        scrollToId("target", 0);
+        expect(window.scrollTo).not.toHaveBeenCalled();
+
+        // première frame: l'élément n'existe pas, on simule le retry
+        callbacks[0](0);
+        expect(window.requestAnimationFrame).toHaveBeenCalledTimes(2);
+
+        // on ajoute l'élément et on exécute la seconde frame
+        document.body.innerHTML = `<section id="target" tabindex="-1">X</section>`;
+        const target = document.getElementById("target")!;
+        target.getBoundingClientRect = () => ({
+            top: 300,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            width: 0,
+            height: 0,
+            x: 0,
+            y: 0,
+            toJSON() {
+                return {};
+            },
+        });
+        callbacks[1](0);
+
+        expect(window.scrollTo).toHaveBeenCalledWith({ top: 300 + 100, behavior: "smooth" });
     });
 });


### PR DESCRIPTION
## Description
- attente de l’élément cible via `requestAnimationFrame`
- respect de `prefers-reduced-motion` et focus sans scroll
- mise à jour des tests unitaires

## Tests effectués
- `yarn install` *(erreur : @aws-sdk/types non résolu)*
- `yarn lint` *(erreur : Couldn't find the node_modules state file)*
- `yarn prettier src/menu/scroll/scrollToId.ts tests/unit/menu.scroll.test.ts --write` *(erreur : Couldn't find the node_modules state file)*
- `yarn test:unit` *(erreur : Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a9871a848324bd790e7f38302293