### PR TITLE
[Feat] test de scroll par hash

### DIFF
--- a/tests/e2e/hash-scroll.spec.ts
+++ b/tests/e2e/hash-scroll.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "playwright/test";
+
+test.describe("Hash scroll", () => {
+    test("scroll avec offset vers l'ancre", async ({ page }) => {
+        await page.goto("/services#avec-permis");
+
+        const { scrollY, targetY } = await page.evaluate(() => {
+            const target = document.getElementById("avec-permis");
+            return {
+                scrollY: window.scrollY,
+                targetY: target?.offsetTop ?? null,
+            };
+        });
+
+        expect(targetY).not.toBeNull();
+        const offset = 102;
+        expect(Math.abs(scrollY - (targetY - offset))).toBeLessThan(5);
+    });
+});


### PR DESCRIPTION
## Description
- ajouter un test Playwright pour vérifier le scroll avec offset sur `/services#avec-permis`

## Tests effectués
- `yarn install` *(erreur : @aws-sdk/types@npm:^3.876.0 introuvable)*
- `yarn lint` *(échec : node_modules manquant)*
- `yarn test:e2e` *(échec : node_modules manquant)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ad595d7083248538ac5c3534de04