### PR TITLE
[Feat] tests offset de défilement

### DIFF
--- a/tests/unit/menu.scroll.test.ts
+++ b/tests/unit/menu.scroll.test.ts
@@ -77,7 +77,7 @@ describe("scrollToId", () => {
         expect(window.scrollTo).toHaveBeenCalledWith({ top: 300 + 100, behavior: "auto" });
     });
 
-    it("réessaie jusqu’à trouver l’élément", () => {
+    it("réessaie jusqu’à trouver l’élément (offset inclus)", () => {
         document.body.innerHTML = ""; // élément absent initialement
         const callbacks: FrameRequestCallback[] = [];
         window.requestAnimationFrame = vi.fn((cb: FrameRequestCallback) => {
@@ -85,7 +85,7 @@ describe("scrollToId", () => {
             return 0;
         });
 
-        scrollToId("target", 0);
+        scrollToId("target", 64);
         expect(window.scrollTo).not.toHaveBeenCalled();
 
         // première frame: l'élément n'existe pas, on simule le retry
@@ -110,6 +110,6 @@ describe("scrollToId", () => {
         });
         callbacks[1](0);
 
-        expect(window.scrollTo).toHaveBeenCalledWith({ top: 300 + 100, behavior: "smooth" });
+        expect(window.scrollTo).toHaveBeenCalledWith({ top: 300 + 100 - 64, behavior: "smooth" });
     });
 });

--- a/tests/unit/resolveScrollOffset.test.ts
+++ b/tests/unit/resolveScrollOffset.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { resolveScrollOffset } from "@/menu/scroll/resolveScrollOffset";
+
+describe("resolveScrollOffset", () => {
+    it("privilégie l'offset du MenuItem", () => {
+        const offset = resolveScrollOffset({ scrollOffset: 10 }, { scrollOffset: 20 });
+        expect(offset).toBe(10);
+    });
+
+    it("utilise l'offset du SubItem si celui du MenuItem est absent", () => {
+        const offset = resolveScrollOffset(undefined, { scrollOffset: 30 });
+        expect(offset).toBe(30);
+    });
+
+    it("retourne 0 si aucun offset n'est défini", () => {
+        const offset = resolveScrollOffset();
+        expect(offset).toBe(0);
+    });
+});


### PR DESCRIPTION
## Description
- ajoute les tests de priorité pour `resolveScrollOffset`
- vérifie que `scrollToId` applique l’offset après retry

## Tests effectués
- `yarn install` *(échec : No candidates found for @aws-sdk/types@npm:^3.876.0)*
- `npx prettier --write tests/unit/menu.scroll.test.ts tests/unit/resolveScrollOffset.test.ts`
- `yarn lint` *(échec : Couldn't find the node_modules state file)*
- `yarn test:unit` *(échec : Couldn't find the node_modules state file)*


------
https://chatgpt.com/codex/tasks/task_e_68b0ad48965483249a89238140791924