### PR TITLE
[Fix] Ajuste configuration des tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,7 +4,7 @@ import { defineConfig, devices } from "playwright/test";
 export default defineConfig({
     // Spécifie le répertoire contenant les tests end-to-end
     testDir: "./tests/e2e",
-    reporter: [["html", { open: "never" }]],
+    reporter: "html",
     use: {
         baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000",
         ...devices["Desktop Chrome"],

--- a/tests/setupTests.ts
+++ b/tests/setupTests.ts
@@ -1,1 +1,19 @@
-export { server } from "./_legacy/setupTests";
+import { Amplify } from "aws-amplify";
+import { beforeAll, afterEach, afterAll } from "vitest";
+import { setupServer } from "msw/node";
+import outputs from "@/amplify_outputs.json";
+import "@testing-library/jest-dom/vitest";
+import "whatwg-fetch";
+
+/**
+ * Initialisation du mock AWS Amplify et du serveur MSW pour l'ensemble des tests.
+ * Ce fichier configure Amplify avec les sorties locales et démarre MSW pour intercepter les requêtes réseau.
+ */
+export const server = setupServer();
+
+beforeAll(() => {
+    Amplify.configure(outputs);
+    server.listen();
+});
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
     },
     test: {
         environment: "jsdom",
-        setupFiles: ["./tests/_legacy/setupTests.ts"],
+        setupFiles: ["./tests/setupTests.ts"],
         exclude: ["**/node_modules/**", "tests/e2e/**"],
     },
 });


### PR DESCRIPTION
## Description
- Centralisation des mocks Amplify et MSW dans `tests/setupTests.ts`.
- Vitest utilise désormais ce fichier de setup et exclut `tests/e2e`.
- Playwright est configuré pour exécuter les tests E2E depuis `tests/e2e` avec un reporter HTML.

## Tests effectués
- `yarn install` (échec : lockfile immuable)
- `yarn prettier --write vitest.config.ts tests/setupTests.ts playwright.config.ts` (échec : dépendances manquantes)
- `yarn lint` (échec : dépendances manquantes)
- `yarn test:unit` (échec : dépendances manquantes)
- `yarn test:integration` (échec : dépendances manquantes)
- `yarn test:e2e` (échec : dépendances manquantes)

## Checklist de vérification
- [ ] Tous les tests unitaires passent
- [ ] Tous les tests d’intégration passent
- [ ] Tous les tests E2E passent
- [ ] Les tests modifiés sont documentés et commentés si nécessaire
- [ ] La couverture de code reste satisfaisante

## Bénéfices
- Maintien de la fiabilité et de la robustesse du projet
- Réduction du risque de régressions
- Documentation claire pour le suivi des changements

------
https://chatgpt.com/codex/tasks/task_e_68b0af58ff9883248e2fe194a605d32b