### PR TITLE
[Feat] reset du bouton de recherche selon la requête

### DIFF
--- a/src/components/header/navInput/NavInput.tsx
+++ b/src/components/header/navInput/NavInput.tsx
@@ -82,8 +82,8 @@ const NavInput: React.FC<NavInputProps> = ({
                     onFocus={onFocus}
                     handleSearch={handleSearch}
                     handleSubmit={handleSubmit}
-                    isSubmitted={isSubmitted} // Ajouter cette prop
-                    handleReset={handleReset} // Ajouter cette prop
+                    isSubmitted={isSubmitted}
+                    handleReset={handleReset}
                 />
             </form>
             {renderSubResult()}

--- a/src/components/header/navInput/RenderInput.tsx
+++ b/src/components/header/navInput/RenderInput.tsx
@@ -35,6 +35,7 @@ const RenderInput: React.FC<RenderInputProps> = ({
     return (
         <>
             <RenderInputButton
+                hasQuery={query.length > 0}
                 isSubmitted={isSubmitted}
                 showNavLinks={showNavLinks}
                 menuItem={{ svg: menuItem.svg as keyof typeof svgComponents }}

--- a/src/components/header/navInput/RenderInputButton.tsx
+++ b/src/components/header/navInput/RenderInputButton.tsx
@@ -3,6 +3,7 @@ import { svgComponents } from "../svgComponents";
 import SearchClose from "../../svg_Icon/SearchClose";
 
 interface RenderButtonProps {
+    hasQuery: boolean;
     isSubmitted: boolean;
     showNavLinks: boolean;
     menuItem: { svg: SvgComponentKey };
@@ -12,6 +13,7 @@ interface RenderButtonProps {
 
 type SvgComponentKey = keyof typeof svgComponents;
 const RenderInputButton: React.FC<RenderButtonProps> = ({
+    hasQuery,
     isSubmitted,
     showNavLinks,
     menuItem,
@@ -19,22 +21,23 @@ const RenderInputButton: React.FC<RenderButtonProps> = ({
     handleReset,
 }) => {
     const SvgIcon = svgComponents[menuItem.svg];
-    const handleClick = isSubmitted ? handleReset : handleSubmit;
+    const shouldReset = hasQuery || isSubmitted;
+    const handleClick = shouldReset ? handleReset : handleSubmit;
 
     if (!showNavLinks) return SvgIcon ? <SvgIcon /> : null;
 
     return (
         <button
-            type={isSubmitted ? "button" : "submit"}
+            type={shouldReset ? "button" : "submit"}
             className="nav-icon flx-c"
             onClick={handleClick}
             aria-label={
-                isSubmitted
+                shouldReset
                     ? "Réinitialiser la recherche"
                     : "Valider la recherche"
             }
         >
-            {isSubmitted ? <SearchClose /> : SvgIcon && <SvgIcon />}
+            {shouldReset ? <SearchClose /> : SvgIcon && <SvgIcon />}
         </button>
     );
 };

--- a/tests/unit/renderInputButton.test.tsx
+++ b/tests/unit/renderInputButton.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import RenderInputButton from "@components/header/navInput/RenderInputButton";
+import { svgComponents } from "@components/header/svgComponents";
+
+describe("RenderInputButton", () => {
+    const menuItem = { svg: "Search" as keyof typeof svgComponents };
+
+    it("affiche le bouton de réinitialisation et appelle handleReset quand une requête est présente", () => {
+        const handleReset = vi.fn();
+        const handleSubmit = vi.fn();
+        const { getByRole, container } = render(
+            <RenderInputButton
+                hasQuery={true}
+                isSubmitted={false}
+                showNavLinks={true}
+                menuItem={menuItem}
+                handleSubmit={handleSubmit}
+                handleReset={handleReset}
+            />
+        );
+
+        const button = getByRole("button", { name: "Réinitialiser la recherche" });
+        fireEvent.click(button);
+        expect(handleReset).toHaveBeenCalled();
+        expect(container.querySelector(".close-search")).toBeTruthy();
+    });
+
+    it("appelle handleSubmit quand aucune requête n'est présente", () => {
+        const handleReset = vi.fn();
+        const handleSubmit = vi.fn();
+        const { getByRole, container } = render(
+            <RenderInputButton
+                hasQuery={false}
+                isSubmitted={false}
+                showNavLinks={true}
+                menuItem={menuItem}
+                handleSubmit={handleSubmit}
+                handleReset={handleReset}
+            />
+        );
+
+        const button = getByRole("button", { name: "Valider la recherche" });
+        fireEvent.click(button);
+        expect(handleSubmit).toHaveBeenCalled();
+        expect(container.querySelector(".close-search")).toBeNull();
+    });
+});


### PR DESCRIPTION
## Description
- gère l'état `hasQuery` pour le bouton de recherche
- propage `query` jusqu'à `RenderInputButton`
- ajoute des tests unitaires pour la réinitialisation

## Tests effectués
- `yarn install` *(échoue : yarn non installé)*
- `yarn lint` *(échoue : yarn non installé)*
- `yarn tsc -noEmit` *(échoue : yarn non installé)*
- `yarn test:unit` *(échoue : yarn non installé)*

------
https://chatgpt.com/codex/tasks/task_e_68b11d40af40832482f1413bcdd9f0f5