### PR TITLE
[Feat] blocage de la propagation sur les suggestions de recherche

### DIFF
--- a/src/components/header/navInput/SubResult.tsx
+++ b/src/components/header/navInput/SubResult.tsx
@@ -6,11 +6,7 @@ interface SubResultProps {
     onSuggestionClick: (suggestion: string) => void;
 }
 
-const SubResult: React.FC<SubResultProps> = ({
-    suggestions,
-    isOpen,
-    onSuggestionClick,
-}) => {
+const SubResult: React.FC<SubResultProps> = ({ suggestions, isOpen, onSuggestionClick }) => {
     if (!suggestions || suggestions.length === 0) return null;
 
     return (
@@ -23,6 +19,7 @@ const SubResult: React.FC<SubResultProps> = ({
                         className="nav-link"
                         onClick={(e) => {
                             e.preventDefault();
+                            e.stopPropagation();
                             onSuggestionClick(suggestion); // Appelle la méthode depuis NavInput
                         }}
                     >

--- a/tests/integration/navInput.integration.test.tsx
+++ b/tests/integration/navInput.integration.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import * as React from "react";
+import NavInput from "../../src/components/header/navInput/NavInput";
+import { SearchProvider } from "../../src/utils/context/SearchContext";
+import { menuItems } from "../../src/assets/data/menuItems";
+
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ push: vi.fn() }),
+    useSearchParams: () => new URLSearchParams(),
+}));
+
+describe("NavInput suggestions", () => {
+    it("ferme le sous-menu après un clic sur une suggestion", async () => {
+        render(
+            <SearchProvider>
+                <NavInput
+                    menuItem={menuItems.search[0]}
+                    isOpen={true}
+                    showNavLinks={true}
+                    placeholder="Rechercher..."
+                    onMenuToggle={() => {}}
+                    onMouseEnter={() => {}}
+                    onFocus={() => {}}
+                />
+            </SearchProvider>
+        );
+
+        const input = screen.getByPlaceholderText(/Rechercher\.\.\./i);
+        fireEvent.change(input, { target: { value: "contact" } });
+
+        const suggestion = await screen.findByText("contact");
+        fireEvent.click(suggestion);
+
+        await waitFor(() => {
+            expect(screen.queryByText("contact")).toBeNull();
+        });
+    });
+});


### PR DESCRIPTION
## Description
- empêche la propagation des clics sur les suggestions
- ajoute un test d'intégration vérifiant la fermeture du sous-menu

## Tests effectués
- `yarn lint`
- `yarn tsc -noEmit`
- `yarn test:integration` *(échec : tests/integration/menu.legacy.integration.test.tsx)*
- `npx vitest run tests/integration/navInput.integration.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b11d42ca0c8324bf46f934130a88d1