### PR TITLE
[Feat] fermeture du menu après sélection d'une suggestion

### DIFF
--- a/src/components/header/navInput/NavInput.tsx
+++ b/src/components/header/navInput/NavInput.tsx
@@ -37,6 +37,11 @@ const NavInput: React.FC<NavInputProps> = ({
         handleSuggestionClick,
     } = useSearchHandler(router);
 
+    const onSuggestionSelect = (suggestion: string) => {
+        handleSuggestionClick(suggestion);
+        onMenuToggle(menuItem.id);
+    };
+
     const handleKeyDown = (e: React.KeyboardEvent) => {
         if (["Enter", " "].includes(e.key)) {
             e.preventDefault();
@@ -51,7 +56,7 @@ const NavInput: React.FC<NavInputProps> = ({
             <SubResult
                 suggestions={suggestions}
                 isOpen={isOpen}
-                onSuggestionClick={handleSuggestionClick}
+                onSuggestionSelect={onSuggestionSelect}
             />
         );
 

--- a/src/components/header/navInput/SubResult.tsx
+++ b/src/components/header/navInput/SubResult.tsx
@@ -3,10 +3,10 @@ import React from "react";
 interface SubResultProps {
     suggestions: string[];
     isOpen: boolean;
-    onSuggestionClick: (suggestion: string) => void;
+    onSuggestionSelect: (suggestion: string) => void;
 }
 
-const SubResult: React.FC<SubResultProps> = ({ suggestions, isOpen, onSuggestionClick }) => {
+const SubResult: React.FC<SubResultProps> = ({ suggestions, isOpen, onSuggestionSelect }) => {
     if (!suggestions || suggestions.length === 0) return null;
 
     return (
@@ -20,7 +20,7 @@ const SubResult: React.FC<SubResultProps> = ({ suggestions, isOpen, onSuggestion
                         onClick={(e) => {
                             e.preventDefault();
                             e.stopPropagation();
-                            onSuggestionClick(suggestion); // Appelle la méthode depuis NavInput
+                            onSuggestionSelect(suggestion); // Appelle la méthode depuis NavInput
                         }}
                     >
                         {suggestion}


### PR DESCRIPTION
## Description
- assure la fermeture du menu lors de la sélection d'une suggestion de recherche

## Tests effectués
- `yarn lint`
- `yarn test:integration` *(échoue: `menu legacy > ouvre et ferme un sous-menu via clic puis clavier`)*

------
https://chatgpt.com/codex/tasks/task_e_68b1237df2548324a97d858ed5245792