### PR TITLE
[Fix] typage updateEntity et labels userProfile

### DIFF
--- a/src/entities/models/userProfile/hooks.tsx
+++ b/src/entities/models/userProfile/hooks.tsx
@@ -100,7 +100,10 @@ export function useUserProfileForm(profile: UserProfileType | null) {
         async (field: keyof UserProfileFormType, value: string) => {
             const id = profileId ?? sub;
             if (!id) return;
-            await userProfileService.update({ id, [field]: value } as any);
+            await userProfileService.update({ id, [field]: value } as Record<
+                keyof UserProfileFormType,
+                string
+            > & { id: string });
             patchForm({ [field]: value } as Partial<UserProfileFormType>);
         },
         [profileId, sub, patchForm]
@@ -114,7 +117,7 @@ export function useUserProfileForm(profile: UserProfileType | null) {
     );
 
     // Petit utilitaire conservé pour compat UI existante
-    const labels = useCallback((field: keyof UserProfileFormType) => fieldLabel(field as any), []);
+    const labels = useCallback((field: keyof UserProfileFormType) => fieldLabel(field), []);
 
     return {
         ...modelForm,


### PR DESCRIPTION
## Description
- typage strict de `updateEntity`
- suppression du cast `any` pour `labels`

## Tests
- `yarn lint` *(échoue : Unexpected any etc.)*
- `yarn tsc -noEmit` *(échoue : erreurs types blogDataService)*
- `yarn test` *(échoue : imports introuvables et tests en échec)*

------
https://chatgpt.com/codex/tasks/task_e_68b22068d7088324bc86adaa8f1461a4