### PR TITLE
[Fix] amélioration du typage des boutons

### DIFF
--- a/src/components/buttons/Buttons.tsx
+++ b/src/components/buttons/Buttons.tsx
@@ -91,8 +91,8 @@ function withIconFontSize(
     icon: React.ReactNode,
     fontSize: "inherit" | "small" | "medium" | "large"
 ) {
-    return React.isValidElement(icon)
-        ? React.cloneElement(icon as React.ReactElement<any>, { fontSize })
+    return React.isValidElement<{ fontSize?: typeof fontSize }>(icon)
+        ? React.cloneElement(icon, { fontSize })
         : icon;
 }
 
@@ -102,7 +102,7 @@ function mergeSx(...parts: Array<SxProps<Theme> | undefined>): SxProps<Theme> | 
     const out: Array<NonNullable<SxProps<Theme>>> = [];
     for (const p of parts) {
         if (!p) continue;
-        if (Array.isArray(p)) out.push(...(p as any));
+        if (Array.isArray(p)) out.push(...(p as Array<NonNullable<SxProps<Theme>>>));
         else out.push(p);
     }
     return out.length ? (out as SxProps<Theme>) : undefined;
@@ -172,7 +172,7 @@ function renderByMode(opts: {
         return (
             <UiButton
                 variantType="icon"
-                href={href as any}
+                {...(href ? { href } : undefined)}
                 icon={iconNode}
                 ariaLabel={ariaLabel ?? label ?? "Action"}
                 intent={intent}
@@ -189,7 +189,7 @@ function renderByMode(opts: {
     return (
         <UiButton
             variantType="button"
-            href={href as any}
+            {...(href ? { href } : undefined)}
             label={label ?? ""}
             icon={iconNode}
             intent={intent}

--- a/src/components/buttons/UiButton.tsx
+++ b/src/components/buttons/UiButton.tsx
@@ -59,7 +59,7 @@ export type UiButtonProps = (ButtonMode | IconMode) & (AsLink | AsButton);
 
 function intentStyles(
     intent: UiButtonIntent | undefined
-): Pick<MuiButtonProps, "color"> & { sx?: SxProps<Theme> } {
+): Required<Pick<MuiButtonProps, "color">> & { sx?: SxProps<Theme> } {
     switch (intent) {
         case "success":
             return { color: "success" };
@@ -77,76 +77,78 @@ function intentStyles(
     }
 }
 
-export const UiButton = forwardRef<HTMLButtonElement, UiButtonProps>(function UiButton(props, ref) {
-    const {
-        variantType,
-        // discriminants nav/action
-        href,
-        // communs
-        intent = "primary",
-        variant,
-        size = "medium",
-        loading = false,
-        tooltip,
-        title,
-        className,
-        sx,
-        disabled,
-        type = "button",
-        buttonProps,
-        iconButtonProps,
-    } = props as UiButtonProps;
+export const UiButton = forwardRef<HTMLButtonElement | HTMLAnchorElement, UiButtonProps>(
+    function UiButton(props, ref) {
+        const {
+            variantType,
+            // discriminants nav/action
+            href,
+            // communs
+            intent = "primary",
+            variant,
+            size = "medium",
+            loading = false,
+            tooltip,
+            title,
+            className,
+            sx,
+            disabled,
+            type = "button",
+            buttonProps,
+            iconButtonProps,
+        } = props;
 
-    const { onClick: buttonOnClick, ...restButtonProps } = buttonProps ?? {};
-    const { onClick: iconButtonOnClick, ...restIconButtonProps } = iconButtonProps ?? {};
+        const { onClick: buttonOnClick, ...restButtonProps } = buttonProps ?? {};
+        const { onClick: iconButtonOnClick, ...restIconButtonProps } = iconButtonProps ?? {};
 
-    const iv = intentStyles(intent);
-    const mergedSx = (
-        Array.isArray(sx) ? [{}, iv.sx, ...sx] : { ...iv.sx, ...sx }
-    ) as SxProps<Theme>;
-    const isDisabled = disabled || loading;
+        const iv: { color: MuiButtonProps["color"]; sx?: SxProps<Theme> } = intentStyles(intent);
+        const mergedSx: SxProps<Theme> = Array.isArray(sx)
+            ? ([{}, iv.sx, ...sx] as SxProps<Theme>)
+            : ({ ...iv.sx, ...sx } as SxProps<Theme>);
+        const isDisabled = disabled || loading;
 
-    // Rendu discriminé
-    const content =
-        variantType === "button" ? (
-            <MuiButton
-                ref={ref}
-                component={href ? NextLink : undefined}
-                href={href}
-                onClick={buttonOnClick}
-                size={size}
-                color={iv.color}
-                variant={variant ?? (intent === "ghost" ? "outlined" : "contained")}
-                className={className}
-                sx={mergedSx}
-                disabled={isDisabled}
-                startIcon={props.icon}
-                type={type}
-                title={title}
-                {...restButtonProps}
-            >
-                {loading ? <CircularProgress size={18} /> : props.label}
-            </MuiButton>
-        ) : (
-            <MuiIconButton
-                ref={ref as any}
-                component={href ? NextLink : undefined}
-                {...((href ? { href } : {}) as any)}
-                onClick={iconButtonOnClick}
-                size={size}
-                color={iv.color as any}
-                className={className}
-                sx={mergedSx}
-                disabled={isDisabled}
-                title={title}
-                aria-label={props.ariaLabel}
-                {...restIconButtonProps}
-            >
-                {loading ? <CircularProgress size={18} /> : props.icon}
-            </MuiIconButton>
-        );
+        // Rendu discriminé
+        const content =
+            variantType === "button" ? (
+                <MuiButton
+                    ref={ref as React.Ref<HTMLButtonElement>}
+                    component={href ? NextLink : undefined}
+                    href={href}
+                    onClick={buttonOnClick}
+                    size={size}
+                    color={iv.color}
+                    variant={variant ?? (intent === "ghost" ? "outlined" : "contained")}
+                    className={className}
+                    sx={mergedSx}
+                    disabled={isDisabled}
+                    startIcon={props.icon}
+                    type={type}
+                    title={title}
+                    {...restButtonProps}
+                >
+                    {loading ? <CircularProgress size={18} /> : props.label}
+                </MuiButton>
+            ) : (
+                <MuiIconButton
+                    ref={ref as unknown as React.Ref<HTMLButtonElement>}
+                    component={href ? NextLink : undefined}
+                    {...(href ? { href } : undefined)}
+                    onClick={iconButtonOnClick}
+                    size={size}
+                    color={iv.color}
+                    className={className}
+                    sx={mergedSx}
+                    disabled={isDisabled}
+                    title={title}
+                    aria-label={props.ariaLabel}
+                    {...restIconButtonProps}
+                >
+                    {loading ? <CircularProgress size={18} /> : props.icon}
+                </MuiIconButton>
+            );
 
-    return tooltip ? <Tooltip title={tooltip}>{content}</Tooltip> : content;
-});
+        return tooltip ? <Tooltip title={tooltip}>{content}</Tooltip> : content;
+    }
+);
 
 export default UiButton;


### PR DESCRIPTION
## Description
- rationalise le typage des références `ref` pour les boutons
- supprime les `as any` dans les helpers `mergeSx` et `withIconFontSize`
- propage correctement `href` sans cast superflu

## Tests effectués
- `yarn lint` *(échoué : plusieurs erreurs ESLint existantes)*
- `yarn tsc -noEmit` *(échoué : types manquants dans blogDataService)*
- `yarn test` *(échoué : imports introuvables et tests unitaires en échec)*

------
https://chatgpt.com/codex/tasks/task_e_68b2206bcb308324963f270b0d1f56db