### PR TITLE
[Fix] Typage de mise à jour du pseudo

### DIFF
--- a/src/entities/models/userName/hooks.tsx
+++ b/src/entities/models/userName/hooks.tsx
@@ -9,7 +9,11 @@ import {
     toUserNameCreate,
     toUserNameUpdate,
 } from "@entities/models/userName/form";
-import type { UserNameFormType, UserNameType } from "@entities/models/userName/types";
+import type {
+    UserNameFormType,
+    UserNameType,
+    UserNameTypeUpdateInput,
+} from "@entities/models/userName/types";
 import { emitUserNameUpdated } from "./bus";
 
 type Extras = { userNames: UserNameType[] };
@@ -136,7 +140,10 @@ export function useUserNameForm(userName: UserNameType | null) {
         async (field: keyof UserNameFormType, value: string) => {
             const id = userNameId ?? sub;
             if (!id) return;
-            await userNameService.update({ id, [field]: value } as any);
+            await userNameService.update({
+                id,
+                [field]: value,
+            } as UserNameTypeUpdateInput & { id: string });
             patchForm({ [field]: value } as Partial<UserNameFormType>); // optimiste
             await refresh();
             emitUserNameUpdated();


### PR DESCRIPTION
## Description
- importation de `UserNameTypeUpdateInput`
- typage strict pour `userNameService.update`

## Tests effectués
- `yarn lint` *(échecs)*
- `yarn tsc -noEmit`
- `yarn test` *(échecs)*

------
https://chatgpt.com/codex/tasks/task_e_68b22d7f5edc83248ed23dcdc5418465