### PR TITLE
[Fix] typage des tests du service todo

### DIFF
--- a/src/entities/models/todo/__tests__/service.test.ts
+++ b/src/entities/models/todo/__tests__/service.test.ts
@@ -35,37 +35,41 @@ beforeEach(() => {
 describe("todoService", () => {
     it("get utilise le fallback d'authentification", async () => {
         const fetchSpy = vi.spyOn(global, "fetch");
-        const res = await todoService.get({ id: "1" } as any);
+        const res = await todoService.get({ id: "1" });
+        const calls = fetchSpy.mock.calls as [RequestInfo, RequestInit][];
         expect(fetchSpy).toHaveBeenCalledTimes(2);
-        expect((fetchSpy.mock.calls[0][1] as any).headers["x-auth-mode"]).toBe("apiKey");
-        expect((fetchSpy.mock.calls[1][1] as any).headers["x-auth-mode"]).toBe("userPool");
+        expect(new Headers(calls[0][1].headers).get("x-auth-mode")).toBe("apiKey");
+        expect(new Headers(calls[1][1].headers).get("x-auth-mode")).toBe("userPool");
         expect(res.data).toEqual({ id: 1 });
         fetchSpy.mockRestore();
     });
 
     it("create utilise userPool", async () => {
         const fetchSpy = vi.spyOn(global, "fetch");
-        const res = await todoService.create({} as any);
+        const res = await todoService.create({ content: "" });
+        const calls = fetchSpy.mock.calls as [RequestInfo, RequestInit][];
         expect(fetchSpy).toHaveBeenCalledTimes(1);
-        expect((fetchSpy.mock.calls[0][1] as any).headers["x-auth-mode"]).toBe("userPool");
+        expect(new Headers(calls[0][1].headers).get("x-auth-mode")).toBe("userPool");
         expect(res.data).toEqual({ id: 1 });
         fetchSpy.mockRestore();
     });
 
     it("update utilise userPool", async () => {
         const fetchSpy = vi.spyOn(global, "fetch");
-        const res = await todoService.update({ id: "1" } as any);
+        const res = await todoService.update({ id: "1", content: "" });
+        const calls = fetchSpy.mock.calls as [RequestInfo, RequestInit][];
         expect(fetchSpy).toHaveBeenCalledTimes(1);
-        expect((fetchSpy.mock.calls[0][1] as any).headers["x-auth-mode"]).toBe("userPool");
+        expect(new Headers(calls[0][1].headers).get("x-auth-mode")).toBe("userPool");
         expect(res.data).toEqual({ id: 1 });
         fetchSpy.mockRestore();
     });
 
     it("delete utilise userPool", async () => {
         const fetchSpy = vi.spyOn(global, "fetch");
-        const res = await todoService.delete({ id: "1" } as any);
+        const res = await todoService.delete({ id: "1" });
+        const calls = fetchSpy.mock.calls as [RequestInfo, RequestInit][];
         expect(fetchSpy).toHaveBeenCalledTimes(1);
-        expect((fetchSpy.mock.calls[0][1] as any).headers["x-auth-mode"]).toBe("userPool");
+        expect(new Headers(calls[0][1].headers).get("x-auth-mode")).toBe("userPool");
         expect(res.data).toEqual({ id: 1 });
         fetchSpy.mockRestore();
     });


### PR DESCRIPTION
## Description
- typage strict des appels au service todo
- utilisation de `RequestInit` pour inspecter `fetch`

## Tests effectués
- `yarn lint` *(échecs)*
- `yarn tsc -noEmit`
- `yarn test` *(échecs)*

------
https://chatgpt.com/codex/tasks/task_e_68b22d796028832491deb951ba8779b3