### PR TITLE
[Fix] Ajout des setters de message/erreur au deleteEntity de Section

### DIFF
--- a/src/entities/models/section/hooks.tsx
+++ b/src/entities/models/section/hooks.tsx
@@ -125,7 +125,7 @@ export function useSectionForm(section: SectionType | null) {
                 setMessage("Erreur lors de la suppression de la section.");
             }
         },
-        [listSections, sectionId, refresh]
+        [listSections, sectionId, refresh, setMessage, setError]
     );
 
     return {


### PR DESCRIPTION
## Description
- ajoute `setMessage` et `setError` dans les dépendances du callback `deleteEntity`

## Tests effectués
- `yarn install`
- `yarn lint` *(échecs connus)*
- `yarn tsc -noEmit`
- `yarn test` *(échecs connus)*

------
https://chatgpt.com/codex/tasks/task_e_68b22d7362f0832492e97bb484a26339