### PR TITLE
[Fix] typage strict des tests syncManyToMany

### DIFF
--- a/src/entities/core/utils/__tests__/syncManyToMany.test.ts
+++ b/src/entities/core/utils/__tests__/syncManyToMany.test.ts
@@ -21,7 +21,7 @@ describe("syncManyToMany", () => {
         it("listByParent retourne les IDs enfant", async () => {
             server.use(
                 http.post("https://api.test/relation", async ({ request }) => {
-                    const body = (await request.json()) as { filter?: Record<string, any> };
+                    const body = (await request.json()) as { filter?: Record<string, unknown> };
                     if (body.filter?.parentId?.eq === "p1") {
                         return HttpResponse.json({
                             data: [
@@ -34,9 +34,9 @@ describe("syncManyToMany", () => {
                 })
             );
             const service = relationService(
-                "TestRelation" as any,
-                "parentId" as any,
-                "childId" as any
+                "TestRelation" as never,
+                "parentId" as never,
+                "childId" as never
             );
             await expect(service.listByParent("p1")).resolves.toEqual(["c1", "c2"]);
         });
@@ -44,7 +44,7 @@ describe("syncManyToMany", () => {
         it("listByChild retourne les IDs parent", async () => {
             server.use(
                 http.post("https://api.test/relation", async ({ request }) => {
-                    const body = (await request.json()) as { filter?: Record<string, any> };
+                    const body = (await request.json()) as { filter?: Record<string, unknown> };
                     if (body.filter?.childId?.eq === "c1") {
                         return HttpResponse.json({
                             data: [
@@ -57,9 +57,9 @@ describe("syncManyToMany", () => {
                 })
             );
             const service = relationService(
-                "TestRelation" as any,
-                "parentId" as any,
-                "childId" as any
+                "TestRelation" as never,
+                "parentId" as never,
+                "childId" as never
             );
             await expect(service.listByChild("c1")).resolves.toEqual(["p1", "p2"]);
         });


### PR DESCRIPTION
## Description
- Remplace `Record<string, any>` par `Record<string, unknown>` dans `syncManyToMany.test`
- Appelle `relationService` avec des paramètres génériques castés en `never`

## Tests effectués
- `yarn prettier --write src/entities/core/utils/__tests__/syncManyToMany.test.ts`
- `yarn lint` *(échoue: Unexpected any, no-unused-vars, etc.)*
- `yarn test` *(échoue: imports introuvables, assertion syncManyToMany)*

------
https://chatgpt.com/codex/tasks/task_e_68b22c59c3948324843dfc579e915c45