### PR TITLE
[Fix] typage listFn dans cascade test

### DIFF
--- a/src/entities/core/services/__tests__/cascade.test.ts
+++ b/src/entities/core/services/__tests__/cascade.test.ts
@@ -21,10 +21,12 @@ describe("cascade helpers", () => {
     });
 
     it("deleteEdges liste et supprime les éléments", async () => {
-        const listFn = vi.fn().mockResolvedValue({ data: [1, 2, 3] });
+        const listFn = vi
+            .fn<(args: { filter: Record<string, unknown> }) => Promise<{ data: number[] }>>()
+            .mockResolvedValue({ data: [1, 2, 3] });
         const calls: number[] = [];
         await deleteEdges(
-            listFn as any,
+            listFn,
             async (e: number) => {
                 calls.push(e);
             },


### PR DESCRIPTION
## Description
- typage explicite de listFn dans `cascade.test.ts`
- suppression du cast `any` lors de l'appel à `deleteEdges`

## Tests effectués
- `yarn lint` *(échoue : Unexpected any dans d'autres fichiers)*
- `yarn tsc -noEmit`
- `yarn test` *(échoue : imports manquants et assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68b22c541c4c8324b483e1c869e718db