### PR TITLE
[Fix] ajoute dépendances à exitEditMode

### DIFF
--- a/src/entities/core/hooks/useModelForm.ts
+++ b/src/entities/core/hooks/useModelForm.ts
@@ -147,17 +147,6 @@ export default function useModelForm<
         setError(null);
     }, []);
 
-    /** Quitte le mode édition → repasse en create avec un form neuf (ou fourni) */
-    const exitEditMode = useCallback(
-        (next?: F) => {
-            adoptInitial(next ?? initialForm, "create");
-            setMessage("Retour au mode création.");
-        },
-        [
-            /* eslint-disable-line react-hooks/exhaustive-deps */
-        ]
-    );
-
     const adoptInitial = useCallback((next: F, nextMode: FormMode = "edit") => {
         initialRef.current = next;
         setForm(next);
@@ -165,6 +154,15 @@ export default function useModelForm<
         setError(null);
         setMessage(null);
     }, []);
+
+    /** Quitte le mode édition → repasse en create avec un form neuf (ou fourni) */
+    const exitEditMode = useCallback(
+        (next?: F) => {
+            adoptInitial(next ?? initialForm, "create");
+            setMessage("Retour au mode création.");
+        },
+        [adoptInitial, initialForm]
+    );
 
     const refresh = useCallback(async () => {
         if (!load) return;


### PR DESCRIPTION
## Description
- corrige le hook `exitEditMode` pour inclure `adoptInitial` et `initialForm` dans le tableau de dépendances

## Tests effectués
- `yarn lint` *(échecs)*
- `yarn tsc -noEmit`
- `yarn test` *(échecs)*
- `yarn build` *(interrompu)*

------
https://chatgpt.com/codex/tasks/task_e_68b22c49f9e8832486bef3d758032bd6