### PR TITLE
[Fix] typage des labels du profil

### DIFF
--- a/src/components/Profile/UserProfileManager.tsx
+++ b/src/components/Profile/UserProfileManager.tsx
@@ -12,6 +12,7 @@ import { useUserProfileForm } from "@entities/models/userProfile/hooks";
 import {
     type UserProfileFormType,
     type UserProfileType,
+    type UserProfileTypeUpdateInput,
     initialUserProfileForm,
 } from "@entities/models/userProfile";
 
@@ -108,7 +109,7 @@ export default function UserProfileManager() {
             reset={manager.reset}
             setForm={manager.setForm}
             fields={fields}
-            labels={(f) => fieldLabel(f as any)}
+            labels={(f) => fieldLabel(f as keyof UserProfileTypeUpdateInput)}
             updateEntity={manager.updateEntity}
             clearField={manager.clearField}
             // Wrapper “à la AuthorList.onDeleteById”


### PR DESCRIPTION
## Description
- import `UserProfileTypeUpdateInput` dans `UserProfileManager`
- typage strict de `labels` avec `UserProfileTypeUpdateInput`

## Tests effectués
- `yarn lint` (erreurs)
- `yarn tsc -noEmit`
- `yarn test` (échecs)
- `yarn build` (erreurs)


------
https://chatgpt.com/codex/tasks/task_e_68b22c481dd883249de7cc631cdfa382