### PR TITLE
[Fix] typage explicite de l'icône dans Buttons

### DIFF
--- a/src/components/buttons/Buttons.tsx
+++ b/src/components/buttons/Buttons.tsx
@@ -91,8 +91,15 @@ function withIconFontSize(
     icon: React.ReactNode,
     fontSize: "inherit" | "small" | "medium" | "large"
 ) {
-    return React.isValidElement<{ fontSize?: typeof fontSize }>(icon)
-        ? React.cloneElement(icon, { fontSize })
+    return React.isValidElement<{
+        fontSize?: "inherit" | "small" | "medium" | "large";
+    }>(icon)
+        ? React.cloneElement(
+              icon as React.ReactElement<{
+                  fontSize?: "inherit" | "small" | "medium" | "large";
+              }>,
+              { fontSize }
+          )
         : icon;
 }
 


### PR DESCRIPTION
## Description
- typage générique harmonisé pour `React.isValidElement`
- cast explicite de l'icône avant `React.cloneElement`

## Tests
- `yarn lint` *(échoué : 'NavProps' is defined but never used, etc.)*
- `yarn tsc -noEmit`
- `yarn test` *(échoué : syncManyToMany > appelle createFn et deleteFn avec les ID corrects)*
- `yarn build` *(échoué : mêmes erreurs ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68b2477cce1c8324b05710864bb1ed38