### PR TITLE
[Fix] typage explicite des props IconButton

### DIFF
--- a/src/components/buttons/UiButton.tsx
+++ b/src/components/buttons/UiButton.tsx
@@ -99,7 +99,9 @@ export const UiButton = forwardRef<HTMLButtonElement | HTMLAnchorElement, UiButt
         } = props;
 
         const { onClick: buttonOnClick, ...restButtonProps } = buttonProps ?? {};
-        const { onClick: iconButtonOnClick, ...restIconButtonProps } = iconButtonProps ?? {};
+        const { onClick: iconButtonOnClick, ...restIconButtonProps } = (iconButtonProps ?? {}) as {
+            onClick?: MuiIconButtonProps["onClick"];
+        } & Omit<MuiIconButtonProps, "onClick">;
 
         const iv: { color: MuiButtonProps["color"]; sx?: SxProps<Theme> } = intentStyles(intent);
         const mergedSx: SxProps<Theme> = Array.isArray(sx)


### PR DESCRIPTION
## Description
- déclare `restIconButtonProps` avec un type `Omit<MuiIconButtonProps, "onClick">`

## Tests effectués
- `yarn lint` (erreurs existantes)
- `yarn tsc -noEmit`
- `yarn test` (échecs existants)
- `yarn build` (échecs existants)


------
https://chatgpt.com/codex/tasks/task_e_68b247843d8c8324b7ac5f126e90ca98