### PR TITLE
[Fix] amélioration de l'accessibilité du formulaire de contact

### DIFF
--- a/src/home/contact-section/contactForm/form.jsx
+++ b/src/home/contact-section/contactForm/form.jsx
@@ -3,61 +3,58 @@ import { ValidationError } from "@formspree/react";
 const Form = ({ formData, errors, handleChange, state }) => {
     return (
         <div className="form">
-            <label htmlFor="prenom">
-                Prénom{errors.prenom && "*"}
-                {errors.prenom && (
-                    <p className="error-message">{errors.prenom}</p>
-                )}
-            </label>
+            <label htmlFor="prenom">Prénom{errors.prenom && "*"}</label>
             <input
                 type="text"
                 id="prenom"
                 name="prenom"
                 value={formData.prenom}
                 onChange={handleChange}
+                aria-describedby="prenom-error"
+                autoComplete="given-name"
             />
+            {errors.prenom && (
+                <p id="prenom-error" className="error-message">
+                    {errors.prenom}
+                </p>
+            )}
+            <ValidationError prefix="prenom" field="prenom" errors={state.errors} />
 
-            <ValidationError
-                prefix="prenom"
-                field="prenom"
-                errors={state.errors}
-            />
-
-            <label htmlFor="nom">
-                Nom{errors.nom && "*"}
-                {errors.nom && <p className="error-message">{errors.nom}</p>}
-            </label>
+            <label htmlFor="nom">Nom{errors.nom && "*"}</label>
             <input
                 type="text"
                 id="nom"
                 name="nom"
                 value={formData.nom}
                 onChange={handleChange}
+                aria-describedby="nom-error"
+                autoComplete="family-name"
                 // required
             />
-
+            {errors.nom && (
+                <p id="nom-error" className="error-message">
+                    {errors.nom}
+                </p>
+            )}
             <ValidationError prefix="Nom" field="nom" errors={state.errors} />
 
-            <label htmlFor="email">
-                E-mail{errors.email && errors.telephone && "*"}
-                {errors.email && (
-                    <p className="error-message">{errors.email}</p>
-                )}
-            </label>
+            <label htmlFor="email">E-mail{errors.email && errors.telephone && "*"}</label>
             <input
                 type="email"
                 id="email"
                 name="email"
                 value={formData.email}
                 onChange={handleChange}
+                aria-describedby="email-error"
+                autoComplete="email"
                 // required
             />
-
-            <ValidationError
-                prefix="Email"
-                field="email"
-                errors={state.errors}
-            />
+            {errors.email && (
+                <p id="email-error" className="error-message">
+                    {errors.email}
+                </p>
+            )}
+            <ValidationError prefix="Email" field="email" errors={state.errors} />
         </div>
     );
 };


### PR DESCRIPTION
## Description
- externalise les messages d'erreur hors des labels
- ajoute des identifiants, `aria-describedby` et `autoComplete` aux champs concernés

## Tests effectués
- `yarn lint`
- `yarn test` *(échecs : imports introuvables et assertion syncManyToMany)*
- `npx @axe-core/cli https://example.com` *(erreur : Chrome manquant)*

------
https://chatgpt.com/codex/tasks/task_e_68b25c07d33c83249f83ca475aedb47c