### PR TITLE
[Fix] Ajout de name et autoComplete sur EditField

### DIFF
--- a/src/components/forms/EditField.tsx
+++ b/src/components/forms/EditField.tsx
@@ -30,6 +30,8 @@ export default function EditField<T extends Record<string, unknown>>({
             </label>
             <input
                 id="edit-field"
+                name={String(field)}
+                autoComplete={String(field)}
                 className="edit-field_input"
                 value={value}
                 placeholder={labels(field)}


### PR DESCRIPTION
## Description
- ajoute les attributs `name` et `autoComplete` sur `EditField`

## Tests effectués
- `yarn lint`
- `yarn test` *(échoue : modules introuvables et assertion invalide)*

------
https://chatgpt.com/codex/tasks/task_e_68b25bf4713c83248db459a78e89b38a