### PR TITLE
[Fix] ajoute l'auto-complétion des champs dans EntityForm

### DIFF
--- a/src/components/forms/EntityForm.tsx
+++ b/src/components/forms/EntityForm.tsx
@@ -41,6 +41,7 @@ export default function EntityForm<T extends Record<string, unknown>>({
                     <input
                         id={String(field)}
                         name={String(field)}
+                        autoComplete={String(field)}
                         placeholder={labels(field)}
                         value={String(formData[field] ?? "")}
                         onChange={(e) => setFieldValue(field, e.target.value)}


### PR DESCRIPTION
## Description
- ajoute l'attribut `autoComplete` basé sur le nom du champ dans `EntityForm`

## Tests effectués
- `yarn lint`
- `yarn tsc -noEmit`
- `yarn test` *(échec : 3 suites et 1 test)*

------
https://chatgpt.com/codex/tasks/task_e_68b25bf253f883248f439905a430eb78