### PR TITLE
[Fix] amélioration accessibilité du formulaire de contact

### DIFF
--- a/src/home/contact-section/contactForm/formSuite.jsx
+++ b/src/home/contact-section/contactForm/formSuite.jsx
@@ -3,32 +3,27 @@ import { ValidationError } from "@formspree/react";
 const FormSuite = ({ formData, errors, handleChange, state }) => {
     return (
         <div className="form suite">
-            <label htmlFor="telephone">
-                Téléphone{errors.telephone && errors.email && "*"}
-                {errors.telephone && errors.email && (
-                    <p className="error-message">{errors.telephone}</p>
-                )}
-            </label>
+            <label htmlFor="telephone">Téléphone{errors.telephone && errors.email && "*"}</label>
             <input
                 type="tel"
                 id="telephone"
                 name="telephone"
                 value={formData.telephone}
                 onChange={handleChange}
+                autoComplete="tel"
+                aria-describedby={errors.telephone && errors.email ? "telephone-error" : undefined}
             />
+            {errors.telephone && errors.email && (
+                <p id="telephone-error" className="error-message">
+                    {errors.telephone}
+                </p>
+            )}
 
-            <ValidationError
-                prefix="telephone"
-                field="telephone"
-                errors={state.errors}
-            />
+            <ValidationError prefix="telephone" field="telephone" errors={state.errors} />
 
             <label htmlFor="message">
                 Message
                 {errors.message && "*"}
-                {errors.message && (
-                    <p className="error-message">{errors.message}</p>
-                )}
             </label>
             <textarea
                 id="message"
@@ -36,14 +31,17 @@ const FormSuite = ({ formData, errors, handleChange, state }) => {
                 rows={5}
                 value={formData.message}
                 onChange={handleChange}
+                autoComplete="off"
+                aria-describedby={errors.message ? "message-error" : undefined}
                 // required
             />
+            {errors.message && (
+                <p id="message-error" className="error-message">
+                    {errors.message}
+                </p>
+            )}
 
-            <ValidationError
-                prefix="message"
-                field="message"
-                errors={state.errors}
-            />
+            <ValidationError prefix="message" field="message" errors={state.errors} />
         </div>
     );
 };


### PR DESCRIPTION
## Description
- externalise les messages d'erreur du formulaire de contact
- ajoute les attributs d'accessibilité `aria-describedby` et les identifiants d'erreur
- active l'auto-complétion appropriée pour téléphone et texte libre

## Tests effectués
- `yarn lint`
- `yarn test` *(échecs : imports introuvables et assertion)*
- `npx @axe-core/cli https://example.com` *(échec : Chrome introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68b25bf5fedc8324802a851f7fe9d751