### PR TITLE
[Fix] mapping explicite du menu de connexion

### DIFF
--- a/src/components/header/Nav.tsx
+++ b/src/components/header/Nav.tsx
@@ -136,7 +136,21 @@ const Nav: React.FC<NavProps> = ({
             </nav>
 
             <nav className={`connect`} data-reduced={dataReduced}>
-                {renderMenu(menuItems.connection)}
+                {menuItems.connection?.map((menuItem) => (
+                    <NavLinkShow
+                        openMainButton={openMainButton}
+                        openButton={false}
+                        key={menuItem.id}
+                        menuItem={menuItem}
+                        onNavigationClick={onNavigationClick}
+                        isOpen={openSubMenu === menuItem.id}
+                        handleMenuClick={handleMenuClick}
+                        showNavLinks={openMainButton || openMenu === menuItem.id}
+                        onMouseEnter={() => handleMouseOrFocus(menuItem.id)}
+                        onFocus={() => handleMouseOrFocus(menuItem.id)}
+                        onMenuToggle={(id) => showLink(id)}
+                    />
+                ))}
             </nav>
         </div>
     );


### PR DESCRIPTION
## Description
- remplace `renderMenu` pour la section connexion par un mappage explicite
- garantit la prise en compte de `handleMouseOrFocus` et du calcul `showNavLinks`

## Tests effectués
- `yarn lint`
- `yarn tsc -noEmit`
- `yarn test` *(échecs : imports non résolus et assertion)*
- `yarn build` *(échec : fetch failed / collect page data)*

------
https://chatgpt.com/codex/tasks/task_e_68b260c7b8e08324879a71b013a32d1e