### PR TITLE
[Fix] Typage strict du parcours JSX

### DIFF
--- a/eslint/rules/no-onclick-wrapper.ts
+++ b/eslint/rules/no-onclick-wrapper.ts
@@ -1,5 +1,5 @@
 import { Rule } from "eslint";
-import { JSXOpeningElement } from "estree";
+import { JSXOpeningElement, JSXMemberExpression, JSXIdentifier } from "estree";
 
 const rule: Rule.RuleModule = {
     meta: {
@@ -25,11 +25,13 @@ const rule: Rule.RuleModule = {
                     elementName = node.name.name;
                 } else if (node.name.type === "JSXMemberExpression") {
                     // handle cases like <UI.PowerButton>
-                    let current: any = node.name;
+                    let current: JSXMemberExpression | JSXIdentifier = node.name;
                     while (current.type === "JSXMemberExpression") {
                         current = current.property;
                     }
-                    elementName = current.name;
+                    if (current.type === "JSXIdentifier") {
+                        elementName = current.name;
+                    }
                 }
                 if (
                     elementName &&


### PR DESCRIPTION
## Description
- importe `JSXMemberExpression` depuis `estree`
- typage explicite de `current` et boucle adaptée

## Tests effectués
- `yarn lint` *(échoue : erreurs existantes dans le dépôt)*
- `npx next lint --file eslint/rules/no-onclick-wrapper.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b69f18c0248324b5cc1f903d3389e5