### PR TITLE
[Feat] Normalisation de la structure de tests monorepo

### DIFF
--- a/apps/web/tests/README.md
+++ b/apps/web/tests/README.md
@@ -1,0 +1,36 @@
+# Tests de l'application `web`
+
+Ce dossier centralise tous les tests relatifs à l'app `apps/web`.
+
+## Structure
+
+```
+apps/web/tests/
+├── unit/      # tests de composants et utilitaires spécifiques à l'app
+├── api/       # tests server-side (use-cases)
+├── e2e/       # tests Playwright
+└── _legacy/   # anciens tests en attente de tri
+```
+
+## Lancer les tests
+
+```bash
+yarn test:unit    # tests unitaires (Vitest + RTL)
+yarn test:api     # tests de logique server-side
+yarn test:e2e     # tests end-to-end Playwright
+```
+
+## Ajouter un test
+
+1. Placer le fichier sous le dossier approprié (`unit`, `api` ou `e2e`).
+2. Respecter les conventions `*.test.ts` / `*.test.tsx`.
+3. Utiliser les alias TypeScript (`@ui/*`, `@services/app/*`, etc.).
+4. Les tests unitaires doivent mocker Amplify :
+   ```ts
+   vi.mock('aws-amplify', () => ({ Auth: { signIn: vi.fn() } }));
+   ```
+
+## Mocks d'Amplify
+
+Le fichier `setupTests.ts` fournit des mocks basiques pour `aws-amplify` et `@aws-amplify/ui-react`.  
+Adapter au besoin dans les tests spécifiques.

--- a/apps/web/tests/e2e/example.spec.ts
+++ b/apps/web/tests/e2e/example.spec.ts
@@ -1,6 +1,9 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from '@playwright/test';
 
-test("page d'accueil accessible", async ({ page }) => {
-    await page.goto("/");
-    await expect(page).toHaveTitle(/.+/);
+test('parcours de base', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: /accueil/i })).toBeVisible();
+
+  await page.click('a[href="/blog"]');
+  await expect(page).toHaveURL('/blog');
 });

--- a/apps/web/tests/setupTests.ts
+++ b/apps/web/tests/setupTests.ts
@@ -1,19 +1,29 @@
-import { Amplify } from "aws-amplify";
-import { beforeAll, afterEach, afterAll } from "vitest";
-import { setupServer } from "msw/node";
-import outputs from "@/amplify_outputs.json";
-import "@testing-library/jest-dom/vitest";
-import "whatwg-fetch";
+import '@testing-library/jest-dom';
+import { afterEach, vi } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import { TextEncoder, TextDecoder } from 'util';
 
-/**
- * Initialisation du mock AWS Amplify et du serveur MSW pour l'ensemble des tests.
- * Ce fichier configure Amplify avec les sorties locales et démarre MSW pour intercepter les requêtes réseau.
- */
-export const server = setupServer();
+vi.mock('aws-amplify', () => ({
+  Auth: {
+    signIn: vi.fn(),
+    currentAuthenticatedUser: vi.fn(),
+    signOut: vi.fn(),
+  },
+  API: {
+    get: vi.fn(),
+    post: vi.fn(),
+    del: vi.fn(),
+  },
+}));
 
-beforeAll(() => {
-    Amplify.configure(outputs);
-    server.listen();
+vi.mock('@aws-amplify/ui-react', () => ({
+  Authenticator: ({ children }: any) => children,
+}));
+
+afterEach(() => {
+  cleanup();
 });
-afterEach(() => server.resetHandlers());
-afterAll(() => server.close());
+
+(global as any).URL.createObjectURL =
+  (global as any).URL.createObjectURL || vi.fn();
+Object.assign(global, { TextEncoder, TextDecoder });

--- a/apps/web/tests/unit/example.dom.test.tsx
+++ b/apps/web/tests/unit/example.dom.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Button } from '@ui/button';
+
+describe('Button', () => {
+  it('déclenche le callback au clic', async () => {
+    const handleClick = vi.fn();
+    render(<Button onClick={handleClick}>Envoyer</Button>);
+
+    await userEvent.click(screen.getByRole('button', { name: /envoyer/i }));
+    expect(handleClick).toHaveBeenCalled();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
     "private": true,
     "workspaces": [
         "apps/*",
-        "packages/*"
+        "packages/*",
+        "tooling/*"
     ],
     "packageManager": "yarn@4.9.4",
     "engines": {
@@ -12,7 +13,16 @@
         "dev": "yarn workspace web dev",
         "build": "yarn workspaces foreach -p run build",
         "lint": "yarn workspaces foreach -p run lint",
-        "test": "yarn workspaces foreach -p run test",
+        "test": "pnpm test:unit && pnpm test:api && pnpm test:e2e",
+        "test:unit": "vitest --config tooling/vitest/vitest.config.ts --coverage",
+        "test:api": "vitest --config tooling/vitest/vitest.config.ts run apps/web/tests/api --coverage",
+        "test:e2e": "playwright test -c tooling/playwright/playwright.config.ts",
+        "test:changed": "vitest --config tooling/vitest/vitest.config.ts --changed --watch=false",
+        "e2e:ui": "playwright test -c tooling/playwright/playwright.config.ts --project=chromium",
+        "e2e:headed": "playwright test -c tooling/playwright/playwright.config.ts --headed",
         "test:web": "yarn workspace web test"
+    },
+    "devDependencies": {
+        "vite-tsconfig-paths": "^5.1.4"
     }
 }

--- a/packages/domain/src/normalize.ts
+++ b/packages/domain/src/normalize.ts
@@ -1,0 +1,3 @@
+export function normalize(input: string): string {
+  return input.trim().toLowerCase();
+}

--- a/packages/domain/tests/example.domain.test.ts
+++ b/packages/domain/tests/example.domain.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { normalize } from '@domain/normalize';
+
+describe('normalize', () => {
+  it('retire les espaces et met en minuscule', () => {
+    expect(normalize('  Salut  ')).toBe('salut');
+  });
+});

--- a/packages/services/src/adapters/__tests__/example.adapter.test.ts
+++ b/packages/services/src/adapters/__tests__/example.adapter.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it, vi } from 'vitest';
+import { httpClient } from '@services/adapters/httpClient';
+
+describe('httpClient', () => {
+  it('effectue un GET avec fetch', async () => {
+    const mock = vi.fn().mockResolvedValue({ ok: true, json: () => ({}) });
+    vi.stubGlobal('fetch', mock);
+
+    await httpClient.get('/api/status');
+    expect(mock).toHaveBeenCalledWith('/api/status', expect.any(Object));
+  });
+});

--- a/packages/services/src/adapters/httpClient.ts
+++ b/packages/services/src/adapters/httpClient.ts
@@ -1,0 +1,7 @@
+export const httpClient = {
+  async get(url: string, options?: RequestInit) {
+    const res = await fetch(url, { method: 'GET', ...(options || {}) });
+    if (!res.ok) throw new Error('Network error');
+    return res.json();
+  },
+};

--- a/packages/services/src/adapters/userAdapter.ts
+++ b/packages/services/src/adapters/userAdapter.ts
@@ -1,0 +1,6 @@
+export const userAdapter = {
+  async save(input: { name: string }) {
+    // placeholder implementation
+    return Promise.resolve(input);
+  },
+};

--- a/packages/services/src/app/__tests__/example.usecase.test.ts
+++ b/packages/services/src/app/__tests__/example.usecase.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createUser } from '@services/app/createUser';
+import { userAdapter } from '@services/adapters/userAdapter';
+
+vi.mock('@services/adapters/userAdapter', () => ({
+  userAdapter: { save: vi.fn() },
+}));
+
+describe('createUser', () => {
+  it("délègue la sauvegarde à l'adapter", async () => {
+    const input = { name: 'Ada' };
+    await createUser(input);
+
+    expect(userAdapter.save).toHaveBeenCalledWith(input);
+  });
+});

--- a/packages/services/src/app/createUser.ts
+++ b/packages/services/src/app/createUser.ts
@@ -1,0 +1,5 @@
+import { userAdapter } from '@services/adapters/userAdapter';
+
+export async function createUser(input: { name: string }) {
+  await userAdapter.save(input);
+}

--- a/packages/ui/src/button.tsx
+++ b/packages/ui/src/button.tsx
@@ -1,0 +1,5 @@
+import { ButtonHTMLAttributes } from 'react';
+
+export function Button(props: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return <button {...props} />;
+}

--- a/scripts/codemod-rewrite-test-imports.ts
+++ b/scripts/codemod-rewrite-test-imports.ts
@@ -1,0 +1,48 @@
+import path from 'node:path';
+import { Project } from 'ts-morph';
+
+const root = path.resolve(__dirname, '..');
+
+const project = new Project({
+  tsConfigFilePath: path.join(root, 'tsconfig.base.json'),
+});
+
+project.addSourceFilesAtPaths([
+  'apps/web/tests/**/*.test.ts',
+  'apps/web/tests/**/*.test.tsx',
+  'packages/**/tests/**/*.test.ts',
+  'packages/**/src/**/*.test.ts',
+  'packages/**/src/**/*.test.tsx',
+]);
+
+const mappings = [
+  { match: /apps\/web\/src\/types\//, alias: '@types/' },
+  { match: /apps\/web\/src\/entities\/core\/utils\//, alias: '@domain/' },
+  { match: /apps\/web\/src\/entities\/core\/services\//, alias: '@services/adapters/' },
+  { match: /apps\/web\/src\/services\/adapters\//, alias: '@services/adapters/' },
+  { match: /apps\/web\/src\/services\//, alias: '@services/app/' },
+  { match: /apps\/web\/src\/components\//, alias: '@ui/' },
+];
+
+for (const source of project.getSourceFiles()) {
+  source.getImportDeclarations().forEach((imp) => {
+    const spec = imp.getModuleSpecifierValue();
+    if (!spec.startsWith('.')) return;
+
+    const abs = path.normalize(path.join(path.dirname(source.getFilePath()), spec));
+    let rewritten = spec;
+
+    for (const { match, alias } of mappings) {
+      if (abs.replace(/\\/g, '/').match(match)) {
+        const rel = abs.replace(match, '').replace(/\\/g, '/');
+        rewritten = alias + rel;
+        break;
+      }
+    }
+
+    rewritten = rewritten.replace(/\.(tsx?|js)$/, '');
+    imp.setModuleSpecifier(rewritten);
+  });
+}
+
+project.saveSync();

--- a/scripts/migrate-tests-to-architecture.sh
+++ b/scripts/migrate-tests-to-architecture.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+
+# Création des dossiers cibles
+mkdir -p "$ROOT_DIR/packages/ui/src/__tests__"
+mkdir -p "$ROOT_DIR/packages/domain/tests"
+mkdir -p "$ROOT_DIR/packages/services/src/app/__tests__"
+mkdir -p "$ROOT_DIR/packages/services/src/adapters/__tests__"
+mkdir -p "$ROOT_DIR/apps/web/tests/unit"
+mkdir -p "$ROOT_DIR/apps/web/tests/api"
+mkdir -p "$ROOT_DIR/apps/web/tests/e2e"
+mkdir -p "$ROOT_DIR/apps/web/tests/_legacy"
+
+# Renommer *.spec.* en *.test.*
+find "$ROOT_DIR" -type f \( -name "*.spec.ts" -o -name "*.spec.tsx" -o -name "*.spec.js" \) | while read -r file; do
+  git mv "$file" "${file/.spec./.test.}" 2>/dev/null || mv "$file" "${file/.spec./.test.}"
+
+done
+
+move_or_backup() {
+  local src="$1"
+  local dest="$2"
+  mkdir -p "$(dirname "$dest")"
+  git mv "$src" "$dest" 2>/dev/null || mv "$src" "$dest"
+}
+
+classify() {
+  local file="$1"
+  case "$file" in
+    *src/components*|*src/**/hooks*|*.test.tsx)
+      dest="$ROOT_DIR/packages/ui/src/${file#*src/}"
+      dest="${dest%/*}/__tests__/$(basename "$file")"
+      ;;
+    *normalize*.test.ts|*sync*.test.ts|*toggleId.test.ts|*createModelForm.test.ts|*forms/*.test.ts)
+      dest="$ROOT_DIR/packages/domain/tests/$(basename "$file")"
+      ;;
+    *crudService.test.ts|*amplify*.test.ts|*relationService.test.ts)
+      dest="$ROOT_DIR/packages/services/src/adapters/__tests__/$(basename "$file")"
+      ;;
+    *services/*|*usecase*.test.ts)
+      dest="$ROOT_DIR/packages/services/src/app/__tests__/$(basename "$file")"
+      ;;
+    *tests/e2e/*)
+      dest="$ROOT_DIR/apps/web/tests/e2e/$(basename "$file")"
+      ;;
+    *tests/unit/*)
+      dest="$ROOT_DIR/apps/web/tests/unit/$(basename "$file")"
+      ;;
+    *tests/api/*)
+      dest="$ROOT_DIR/apps/web/tests/api/$(basename "$file")"
+      ;;
+    *)
+      dest="$ROOT_DIR/apps/web/tests/_legacy/$(basename "$file")"
+      ;;
+  esac
+  move_or_backup "$file" "$dest"
+}
+
+find "$ROOT_DIR/apps/web" -type f \( -name "*.test.ts" -o -name "*.test.tsx" \) | while read -r file; do
+  classify "$file"
+
+done

--- a/tooling/playwright/playwright.config.ts
+++ b/tooling/playwright/playwright.config.ts
@@ -1,12 +1,29 @@
-import { defineConfig, devices } from "playwright/test";
+import { defineConfig, devices } from '@playwright/test';
 
-// Configuration Playwright ciblant le dossier des tests E2E
 export default defineConfig({
-    // Spécifie le répertoire contenant les tests end-to-end
-    testDir: "./tests/e2e",
-    reporter: "html",
-    use: {
-        baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000",
-        ...devices["Desktop Chrome"],
+  testDir: '../../apps/web/tests/e2e',
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  retries: 2,
+  use: {
+    baseURL: 'http://localhost:3000',
+    headless: true,
+    trace: 'on-first-retry',
+    video: 'retain-on-failure',
+  },
+  webServer: {
+    command: 'pnpm --filter web dev',
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+  },
+  projects: [
+    {
+      name: 'desktop',
+      use: { ...devices['Desktop Chrome'] },
     },
+    {
+      name: 'mobile',
+      use: { ...devices['Pixel 5'] },
+    },
+  ],
 });

--- a/tooling/vitest/vitest.config.ts
+++ b/tooling/vitest/vitest.config.ts
@@ -1,29 +1,31 @@
-import { defineConfig } from "vitest/config";
-import path from "path";
+import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
-    resolve: {
-        alias: {
-            "@": path.resolve(__dirname, "./"),
-            "@app": path.resolve(__dirname, "app"),
-            "@src": path.resolve(__dirname, "src"),
-            "@amplify": path.resolve(__dirname, "amplify"),
-            "@components": path.resolve(__dirname, "src/components"),
-            "@hooks": path.resolve(__dirname, "src/hooks"),
-            "@context": path.resolve(__dirname, "src/context"),
-            "@utils": path.resolve(__dirname, "src/utils"),
-            "@assets": path.resolve(__dirname, "src/assets"),
-            "@services": path.resolve(__dirname, "src/services"),
-            "@myTypes": path.resolve(__dirname, "src/types"),
-            "@entities": path.resolve(__dirname, "src/entities"),
-            "@public": path.resolve(__dirname, "public"),
-            "@test": path.resolve(__dirname, "tests"),
-            tests: path.resolve(__dirname, "tests"),
-        },
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['apps/web/tests/setupTests.ts'],
+    include: [
+      'packages/**/src/**/*.{test,spec}.ts?(x)',
+      'packages/**/tests/**/*.{test,spec}.ts?(x)',
+      'apps/web/tests/(unit|api)/**/*.{test,spec}.ts?(x)',
+    ],
+    exclude: [
+      'node_modules',
+      '.next',
+      'dist',
+      'coverage',
+      'playwright-report',
+      'apps/web/tests/_legacy/**',
+    ],
+    coverage: {
+      provider: 'v8',
+      reportsDirectory: 'coverage',
+      reporter: ['text', 'lcov'],
     },
-    test: {
-        environment: "jsdom",
-        setupFiles: ["./tests/setupTests.ts"],
-        exclude: ["**/node_modules/**", "tests/e2e/**"],
-    },
+  },
+  esbuild: { jsx: 'automatic', jsxDev: true },
+  server: { fs: { allow: ['./'] } },
 });

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,6 +8,8 @@
         "paths": {
             "@domain/*": ["packages/domain/src/*"],
             "@services/*": ["packages/services/src/*"],
+            "@services/app/*": ["packages/services/src/app/*"],
+            "@services/adapters/*": ["packages/services/src/adapters/*"],
             "@ui/*": ["packages/ui/src/*"],
             "@types/*": ["packages/types/src/*"],
             "@web/*": ["apps/web/src/*"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -13698,6 +13698,14 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-internal@workspace:tooling/eslint-plugin-internal":
+  version: 0.0.0-use.local
+  resolution: "eslint-plugin-internal@workspace:tooling/eslint-plugin-internal"
+  peerDependencies:
+    eslint: ">=9.0.0"
+  languageName: unknown
+  linkType: soft
+
 "eslint-plugin-jsx-a11y@npm:^6.10.0":
   version: 6.10.2
   resolution: "eslint-plugin-jsx-a11y@npm:6.10.2"
@@ -14686,6 +14694,13 @@ __metadata:
     merge2: "npm:^1.4.1"
     slash: "npm:^3.0.0"
   checksum: 10c0/b39511b4afe4bd8a7aead3a27c4ade2b9968649abab0a6c28b1a90141b96ca68ca5db1302f7c7bd29eab66bf51e13916b8e0a3d0ac08f75e1e84a39b35691189
+  languageName: node
+  linkType: hard
+
+"globrex@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "globrex@npm:0.1.2"
+  checksum: 10c0/a54c029520cf58bda1d8884f72bd49b4cd74e977883268d931fd83bcbd1a9eb96d57c7dbd4ad80148fb9247467ebfb9b215630b2ed7563b2a8de02e1ff7f89d1
   languageName: node
   linkType: hard
 
@@ -19148,6 +19163,8 @@ __metadata:
 "root-workspace-0b6124@workspace:.":
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
+  dependencies:
+    vite-tsconfig-paths: "npm:^5.1.4"
   languageName: unknown
   linkType: soft
 
@@ -20574,6 +20591,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tsconfck@npm:^3.0.3":
+  version: 3.1.6
+  resolution: "tsconfck@npm:3.1.6"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  bin:
+    tsconfck: bin/tsconfck.js
+  checksum: 10c0/269c3c513540be44844117bb9b9258fe6f8aeab026d32aeebf458d5299125f330711429dbb556dbf125a0bc25f4a81e6c24ac96de2740badd295c3fb400f66c4
+  languageName: node
+  linkType: hard
+
 "tsconfig-paths-webpack-plugin@npm:^4.2.0":
   version: 4.2.0
   resolution: "tsconfig-paths-webpack-plugin@npm:4.2.0"
@@ -21263,6 +21294,22 @@ __metadata:
   bin:
     vite-node: vite-node.mjs
   checksum: 10c0/0d3589f9f4e9cff696b5b49681fdb75d1638c75053728be52b4013f70792f38cb0120a9c15e3a4b22bdd6b795ad7c2da13bcaf47242d439f0906049e73bdd756
+  languageName: node
+  linkType: hard
+
+"vite-tsconfig-paths@npm:^5.1.4":
+  version: 5.1.4
+  resolution: "vite-tsconfig-paths@npm:5.1.4"
+  dependencies:
+    debug: "npm:^4.1.1"
+    globrex: "npm:^0.1.2"
+    tsconfck: "npm:^3.0.3"
+  peerDependencies:
+    vite: "*"
+  peerDependenciesMeta:
+    vite:
+      optional: true
+  checksum: 10c0/6228f23155ea25d92b1e1702284cf8dc52ad3c683c5ca691edd5a4c82d2913e7326d00708cef1cbfde9bb226261df0e0a12e03ef1d43b6a92d8f02b483ef37e3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
- structure de tests alignée par packages et apps
- configuration unifiée pour Vitest et Playwright
- scripts de migration et codemod des imports de tests

## Tests effectués
- `yarn install`
- `yarn prettier --write .` *(échec : script manquant)*
- `yarn lint` *(échec : option manquante)*
- `pnpm test:unit` *(échec : module vite-tsconfig-paths ESM)*
- `pnpm test:api` *(échec : module vite-tsconfig-paths ESM)*
- `pnpm test:e2e` *(échec : webServer Playwright arrêté prématurément)*

------
https://chatgpt.com/codex/tasks/task_e_68b8aa38a2e083248d2139eb4a77da45