### PR TITLE
[Feat] encapsule fetchBlogData

### DIFF
--- a/apps/web/src/context/DataBlogProvider.tsx
+++ b/apps/web/src/context/DataBlogProvider.tsx
@@ -2,7 +2,7 @@
 "use client";
 import React, { createContext, useContext, useState, useEffect, ReactNode, useMemo } from "react";
 import type { BlogData } from "@packages/types/web/blog";
-import { fetchBlogData } from "@packages/services/adapters/blog/fetchBlogData";
+import { getBlogData } from "@packages/services/app/getBlogData";
 
 interface DataBlogContextProps {
     data: BlogData | null;
@@ -20,7 +20,7 @@ export function DataBlogProvider({ children }: { children: ReactNode }) {
     async function fetchData() {
         try {
             setLoading(true);
-            const json = await fetchBlogData();
+            const json = await getBlogData();
             setData(json);
             setError(null);
         } catch (err: unknown) {

--- a/apps/web/src/utils/blogData/loadData.ts
+++ b/apps/web/src/utils/blogData/loadData.ts
@@ -1,5 +1,5 @@
 // src/utils/loadData.ts
-import { fetchBlogData } from "@packages/services/adapters/blog/fetchBlogData";
+import { getBlogData } from "@packages/services/app/getBlogData";
 import type { Section, Post, Author } from "@packages/types/web/blog";
 
 export async function loadData(): Promise<{
@@ -7,5 +7,5 @@ export async function loadData(): Promise<{
     posts: Post[];
     authors: Author[];
 }> {
-    return await fetchBlogData();
+    return await getBlogData();
 }

--- a/doc.txt
+++ b/doc.txt
@@ -689,4 +689,3 @@ Directory structure:
 - apps/web/src/entities/models/post/service.ts — suppression en cascade mêlée à des appels réseau.
 - apps/web/src/entities/models/tag/service.ts — suppression en cascade mêlée à des appels réseau.
 - apps/web/src/entities/models/section/service.ts — suppression en cascade mêlée à des appels réseau.
-- apps/web/src/context/DataBlogProvider.tsx — gestion d'état et accès réseau dans le même module.

--- a/packages/services/src/app/getBlogData.ts
+++ b/packages/services/src/app/getBlogData.ts
@@ -1,0 +1,11 @@
+import { fetchBlogData } from "@services/adapters/blog/fetchBlogData";
+import type { BlogData } from "@packages/types/web/blog";
+
+export async function getBlogData(): Promise<BlogData> {
+    const data = await fetchBlogData();
+    return {
+        sections: data.sections ?? [],
+        posts: data.posts ?? [],
+        authors: data.authors ?? [],
+    };
+}

--- a/packages/services/src/app/index.ts
+++ b/packages/services/src/app/index.ts
@@ -1,1 +1,2 @@
-export {};
+export { createUser } from "./createUser";
+export { getBlogData } from "./getBlogData";

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,6 +10,7 @@
             "@packages/domain/*": ["packages/domain/src/*"],
             "@services/app/*": ["packages/services/src/app/*"],
             "@services/adapters/*": ["packages/services/src/adapters/*"],
+            "@packages/services/app/*": ["packages/services/src/app/*"],
             "@packages/services/adapters/*": ["packages/services/src/adapters/*"],
             "@ui/*": ["packages/ui/src/*"],
             "@packages/types/*": ["packages/types/src/*"]


### PR DESCRIPTION
## Description
- ajoute le use-case `getBlogData`
- remplace les imports d'adapter par `@packages/services/app`
- exporte les nouveaux use-cases et met à jour l'alias TS
- ajuste la documentation

## Tests effectués
- `yarn lint`
- `yarn tsc -noEmit` (échec : script introuvable)
- `yarn typecheck`
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68b94689766483248e9a784797c509ca