### PR TITLE
[Fix] typage global Amplify

### DIFF
--- a/apps/web/src/amplify/setup.ts
+++ b/apps/web/src/amplify/setup.ts
@@ -1,6 +1,7 @@
 // src/amplify/setup.ts
 import { Amplify } from "aws-amplify";
 import outputs from "@apps/amplify_outputs.json";
+import type { AmplifyGlobal } from "@types/web/amplify/global";
 
 const overrides = {
     auth: {
@@ -15,8 +16,10 @@ const overrides = {
 
 const cfg = { ...outputs, ...overrides };
 
+const globals = globalThis as AmplifyGlobal;
+
 // Idempotence globale (dev + HMR + client/serveur)
-if (!globalThis.__AMPLIFY_CONFIGURED__) {
+if (!globals.__AMPLIFY_CONFIGURED__) {
     Amplify.configure(cfg, { ssr: true }); // <-- ici on balance bien cfg
-    globalThis.__AMPLIFY_CONFIGURED__ = true;
+    globals.__AMPLIFY_CONFIGURED__ = true;
 }

--- a/apps/web/src/amplify/useAmplifyReady.ts
+++ b/apps/web/src/amplify/useAmplifyReady.ts
@@ -2,9 +2,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import type { AmplifyGlobal } from "@types/web/amplify/global";
 
 export function useAmplifyReady() {
-    const [ready, setReady] = useState<boolean>(!!globalThis.__AMPLIFY_CONFIGURED__);
+    const [ready, setReady] = useState<boolean>(
+        !!(globalThis as AmplifyGlobal).__AMPLIFY_CONFIGURED__
+    );
 
     useEffect(() => {
         if (ready) return;
@@ -13,7 +16,7 @@ export function useAmplifyReady() {
         let canceled = false;
         import("@src/amplify/setup")
             .then(() => {
-                if (!canceled) setReady(!!globalThis.__AMPLIFY_CONFIGURED__);
+                if (!canceled) setReady(!!(globalThis as AmplifyGlobal).__AMPLIFY_CONFIGURED__);
             })
             .catch((e) => {
                 console.error("[Amplify] setup import failed:", e);

--- a/packages/types/src/web/amplify/global.d.ts
+++ b/packages/types/src/web/amplify/global.d.ts
@@ -1,5 +1,18 @@
+export interface AmplifyGlobal {
+    __AMPLIFY_CONFIGURED__?: boolean;
+    amplify?: unknown;
+}
+
 declare global {
+    // eslint-disable-next-line no-var
     var __AMPLIFY_CONFIGURED__: boolean | undefined;
+
+    interface Window extends AmplifyGlobal {}
+
+    namespace NodeJS {
+        // eslint-disable-next-line @typescript-eslint/no-empty-interface
+        interface Global extends AmplifyGlobal {}
+    }
 }
 
 export {};


### PR DESCRIPTION
## Description
- typage global pour `amplify` et `__AMPLIFY_CONFIGURED__`
- sécurisation de l'accès aux variables globales d'Amplify

## Tests effectués
- `yarn lint` *(échec: Configuration for rule "boundaries/element-types" is invalid)*
- `yarn dlx tsc -noEmit` *(échec: impossible de trouver le binaire `typescript`)*
- `yarn test` *(échec: ESM-only `vite-tsconfig-paths` non supporté)*
- `yarn build` *(échec: fetch failed lors de la collecte des données de page)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7792b7e083249dab914db0290e76