### PR TITLE
[Fix] restreindre generique K dans MarkdownRenderer

### DIFF
--- a/apps/web/src/components/Blog/MarkdownRenderer.tsx
+++ b/apps/web/src/components/Blog/MarkdownRenderer.tsx
@@ -1,6 +1,7 @@
 // src/components/Blog/MarkdownRenderer.tsx
 "use client";
 import React from "react";
+import type { JSXElementConstructor } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeSanitize, { defaultSchema, type Options as Schema } from "rehype-sanitize";
@@ -13,16 +14,15 @@ type MarkdownRendererProps = {
 };
 
 // Props passés par react-markdown aux composants
-type RendererProps<K extends keyof JSX.IntrinsicElements> = {
+type RendererProps<K extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>> = {
     node?: unknown;
 } & React.ComponentProps<K>;
 
-export function withClass<K extends keyof JSX.IntrinsicElements>(
+export function withClass<K extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>>(
     Tag: K,
     defaultProps?: Partial<React.ComponentProps<K>>
 ) {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    return function Renderer({ node, ...props }: RendererProps<K>) {
+    return function Renderer({ node: _node, ...props }: RendererProps<K>) {
         return <Tag {...defaultProps} {...props} />;
     };
 }


### PR DESCRIPTION
## Description
- restreint le generique `K` et retire le `eslint-disable`

## Tests effectués
- `yarn dlx prettier apps/web/src/components/Blog/MarkdownRenderer.tsx --write`
- `yarn lint` *(erreur: Configuration for rule "boundaries/element-types" is invalid)*
- `yarn tsc -noEmit` *(erreur: Couldn't find a script named "tsc".)*
- `yarn test` *(erreur: "vite-tsconfig-paths" resolved to an ESM file...)*
- `yarn build` *(erreur: Failed to collect page data for /blog/[slug])*


------
https://chatgpt.com/codex/tasks/task_e_68ba779b29508324aa14535539641f20