### PR TITLE
[Fix] utiliser l'alias models pour les types

### DIFF
--- a/apps/web/src/entities/models/author/__tests__/form.test.ts
+++ b/apps/web/src/entities/models/author/__tests__/form.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { faker } from "@faker-js/faker";
 import { toAuthorForm, toAuthorCreate, toAuthorUpdate } from "@domain/models/author/form";
-import type { AuthorType, AuthorFormType } from "@types/models/author/types";
+import type { AuthorType, AuthorFormType } from "models/author/types";
 
 describe("toAuthorForm", () => {
     it("convertit AuthorType en AuthorFormType", () => {

--- a/apps/web/src/entities/models/author/__tests__/useAuthorForm.test.ts
+++ b/apps/web/src/entities/models/author/__tests__/useAuthorForm.test.ts
@@ -2,7 +2,7 @@ import { renderHook, act, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { useAuthorForm } from "@ui/models/author/hooks";
 import { authorService } from "@services/app/models/author/service";
-import { type AuthorType } from "@types/models/author/types";
+import { type AuthorType } from "models/author/types";
 
 vi.mock("@services/app/models/author/service", () => ({
     authorService: {

--- a/apps/web/src/entities/models/post/__tests__/form.test.ts
+++ b/apps/web/src/entities/models/post/__tests__/form.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { faker } from "@faker-js/faker";
 import { toPostForm, toPostCreate, toPostUpdate } from "@domain/models/post/form";
-import type { PostType, PostFormType } from "@types/models/post/types";
+import type { PostType, PostFormType } from "models/post/types";
 
 describe("toPostForm", () => {
     it("convertit PostType en PostFormType", () => {

--- a/apps/web/src/entities/models/post/__tests__/usePostForm.test.ts
+++ b/apps/web/src/entities/models/post/__tests__/usePostForm.test.ts
@@ -1,7 +1,7 @@
 import { renderHook, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { usePostForm } from "@ui/models/post/hooks";
-import { type PostType } from "@types/models/post/types";
+import { type PostType } from "models/post/types";
 import { postService } from "@services/app/models/post/service";
 import { syncPostToTags } from "@domain/relations/postTag";
 import { syncPostToSections } from "@domain/relations/sectionPost";

--- a/apps/web/src/entities/models/section/__tests__/form.test.ts
+++ b/apps/web/src/entities/models/section/__tests__/form.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { faker } from "@faker-js/faker";
 import { toSectionForm, toSectionCreate, toSectionUpdate } from "@domain/models/section/form";
-import type { SectionType, SectionFormType } from "@types/models/section/types";
+import type { SectionType, SectionFormType } from "models/section/types";
 
 describe("toSectionForm", () => {
     it("convertit SectionType en SectionFormType", () => {

--- a/apps/web/src/entities/models/tag/__tests__/form.test.ts
+++ b/apps/web/src/entities/models/tag/__tests__/form.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { faker } from "@faker-js/faker";
 import { toTagForm, toTagCreate, toTagUpdate } from "@domain/models/tag/form";
-import type { TagType, TagFormType } from "@types/models/tag/types";
+import type { TagType, TagFormType } from "models/tag/types";
 
 describe("toTagForm", () => {
     it("convertit TagType en TagFormType", () => {

--- a/apps/web/src/entities/models/tag/__tests__/hooks.test.tsx
+++ b/apps/web/src/entities/models/tag/__tests__/hooks.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { TagType } from "@types/models/tag/types";
-import type { PostType } from "@types/models/post/types";
+import type { TagType } from "models/tag/types";
+import type { PostType } from "models/post/types";
 
 vi.mock("@services/app/models/tag/service", () => ({
     tagService: {

--- a/apps/web/src/entities/models/userName/__tests__/form.test.ts
+++ b/apps/web/src/entities/models/userName/__tests__/form.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { faker } from "@faker-js/faker";
 import { toUserNameForm, toUserNameCreate, toUserNameUpdate } from "@domain/models/userName/form";
-import type { UserNameType, UserNameFormType } from "@types/models/userName/types";
+import type { UserNameType, UserNameFormType } from "models/userName/types";
 
 describe("toUserNameForm", () => {
     it("convertit UserNameType en UserNameFormType", () => {

--- a/apps/web/src/entities/models/userProfile/__tests__/form.test.ts
+++ b/apps/web/src/entities/models/userProfile/__tests__/form.test.ts
@@ -5,7 +5,7 @@ import {
     toUserProfileCreate,
     toUserProfileUpdate,
 } from "@domain/models/userProfile/form";
-import type { UserProfileType, UserProfileFormType } from "@types/models/userProfile/types";
+import type { UserProfileType, UserProfileFormType } from "models/userProfile/types";
 
 describe("toUserProfileForm", () => {
     it("convertit UserProfileType en UserProfileFormType", () => {

--- a/apps/web/src/types/models/comment.ts
+++ b/apps/web/src/types/models/comment.ts
@@ -1,4 +1,4 @@
-import type { BaseModel, UpdateInput, ModelForm } from "@types/core";
+import type { BaseModel, UpdateInput, ModelForm } from "@packages/types/core";
 
 export type CommentModel = BaseModel<"Comment">;
 export type CommentCreateInput = {

--- a/apps/web/src/types/models/todo.ts
+++ b/apps/web/src/types/models/todo.ts
@@ -1,4 +1,4 @@
-import type { BaseModel, UpdateInput, ModelForm } from "@types/core";
+import type { BaseModel, UpdateInput, ModelForm } from "@packages/types/core";
 
 export type TodoModel = BaseModel<"Todo">;
 export type TodoCreateInput = { content?: string };

--- a/apps/web/src/types/models/userName.ts
+++ b/apps/web/src/types/models/userName.ts
@@ -3,4 +3,4 @@ export type {
     UserNameTypeCreateInput,
     UserNameTypeUpdateInput,
     UserNameFormType,
-} from "@types/models/userName/types";
+} from "models/userName/types";

--- a/apps/web/src/types/models/userProfile.ts
+++ b/apps/web/src/types/models/userProfile.ts
@@ -4,4 +4,4 @@ export type {
     UserProfileTypeUpdateInput as UserProfileUpdateInput,
     UserProfileFormType,
     UserProfileMinimalType,
-} from "@types/models/userProfile/types";
+} from "models/userProfile/types";

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -19,6 +19,8 @@
             "@packages/services/adapters/*": ["packages/services/src/adapters/*"],
             "@packages/ui/*": ["packages/ui/src/*"],
             "@types/*": ["packages/types/src/*"],
+            "models/*/types": ["packages/types/src/models/*/types"],
+            "models/*": ["packages/types/src/models/*"],
             "@domain/*": ["packages/domain/src/*"],
             "@services/app/*": ["packages/services/src/app/*"],
             "@services/adapters/*": ["packages/services/src/adapters/*"],


### PR DESCRIPTION
## Résumé
- remplace les imports `@types/models/*/types` par `models/*/types`
- ajoute les chemins `models/*` et `models/*/types` dans le tsconfig
- met à jour les fichiers de types pour utiliser `@packages/types/core`

## Tests
- `yarn lint` (échec: Configuration for rule "boundaries/element-types" is invalid)
- `yarn typecheck` (échec: plusieurs erreurs de type mais aucune TS6137)

------
https://chatgpt.com/codex/tasks/task_e_68ba77a5faa083248d7ca41d25b623a4