### PR TITLE
[Fix] typage explicite des callbacks

### DIFF
--- a/apps/web/src/home/contact-section/contactForm/mapCGU/index.tsx
+++ b/apps/web/src/home/contact-section/contactForm/mapCGU/index.tsx
@@ -8,13 +8,29 @@ interface DrivingFormProps {
     onNewEventChange: (condition: boolean | null) => void;
 }
 
+type Option = {
+    id: string;
+    label: string;
+    value: string;
+    condition: boolean;
+};
+
+type Question = {
+    id: string;
+    question: string;
+    name: string;
+    options: Option[];
+    state: boolean | null;
+    onOptionChange: (condition: boolean | null) => void;
+};
+
 const MapQuestions: React.FC<DrivingFormProps> = ({
     cguState,
     onCguChange,
     newEvent,
     onNewEventChange,
 }) => {
-    const options = [
+    const options: Question[] = [
         {
             id: "cgu",
             question: "J'ai lu et accepté les conditions d'utilisation.",
@@ -55,15 +71,15 @@ const MapQuestions: React.FC<DrivingFormProps> = ({
     };
     return (
         <div className="form-questions flx-c">
-            {options.map((option) => (
+            {options.map((option: Question) => (
                 <div className="questions" key={option.id}>
                     <div className="response boolean-checkbox">
-                        {option.options.map((opt) => (
+                        {option.options.map((opt: Option) => (
                             <InputCheckbox
                                 key={opt.id}
                                 option={opt}
                                 state={option.state}
-                                handleInputClick={(condition) =>
+                                handleInputClick={(condition: boolean) =>
                                     handleInputClick(option.onOptionChange, option.state, condition)
                                 }
                                 question={option.name}

--- a/apps/web/src/home/contact-section/contactForm/mapContactQuestions/index.tsx
+++ b/apps/web/src/home/contact-section/contactForm/mapContactQuestions/index.tsx
@@ -10,6 +10,22 @@ interface DrivingFormProps {
     onSupervisedChange: (condition: boolean | null) => void;
 }
 
+type Option = {
+    id: string;
+    label: string;
+    value: string;
+    condition: boolean;
+};
+
+type Question = {
+    id: string;
+    question: string;
+    name: string;
+    options: Option[];
+    state: boolean | null;
+    onOptionChange: (condition: boolean | null) => void;
+};
+
 const MapQuestions: React.FC<DrivingFormProps> = ({
     locationState,
     onLocationChange,
@@ -18,7 +34,7 @@ const MapQuestions: React.FC<DrivingFormProps> = ({
     onPermitChange,
     onSupervisedChange,
 }) => {
-    const options = [
+    const options: Question[] = [
         {
             id: "location",
             question: "Vous résidez à moins de 50 km du havre ?",
@@ -82,16 +98,16 @@ const MapQuestions: React.FC<DrivingFormProps> = ({
     };
     return (
         <div className="form-questions flx-c">
-            {options.map((option) => (
+            {options.map((option: Question) => (
                 <div className="questions" key={option.id}>
                     <p>{option.question}</p>
                     <div className="response boolean-checkbox">
-                        {option.options.map((opt) => (
+                        {option.options.map((opt: Option) => (
                             <InputCheckbox
                                 key={opt.id}
                                 option={opt}
                                 state={option.state}
-                                handleInputClick={(condition) =>
+                                handleInputClick={(condition: boolean) =>
                                     handleInputClick(option.onOptionChange, option.state, condition)
                                 }
                                 question={option.name}

--- a/apps/web/src/services/blogDataService.ts
+++ b/apps/web/src/services/blogDataService.ts
@@ -7,6 +7,9 @@ import { postTagService } from "@src/entities/relations/postTag/service";
 import { sectionPostService } from "@src/entities/relations/sectionPost/service";
 
 import type { BlogData, Author, Post, Section } from "@packages/types/web/blog";
+import type { TagType } from "@packages/types/models/tag/types";
+import type { PostTagType } from "@packages/types/relations/postTag/types";
+import type { SectionPostType } from "@packages/types/relations/sectionPost/types";
 
 export async function fetchBlogData(): Promise<BlogData> {
     try {
@@ -22,16 +25,16 @@ export async function fetchBlogData(): Promise<BlogData> {
 
         const publicRule: AuthRule[] = [{ allow: "public" }];
 
-        const authorData = authorsRes.data.filter((a) => canAccess(null, a, publicRule));
-        const sectionData = sectionsRes.data.filter((s) => canAccess(null, s, publicRule));
-        const postData = postsRes.data.filter((p) => canAccess(null, p, publicRule));
+        const authorData = authorsRes.data.filter((a: Author) => canAccess(null, a, publicRule));
+        const sectionData = sectionsRes.data.filter((s: Section) => canAccess(null, s, publicRule));
+        const postData = postsRes.data.filter((p: Post) => canAccess(null, p, publicRule));
 
         const tagsById: Record<string, string> = {};
-        tagsRes.data.forEach((t) => {
+        tagsRes.data.forEach((t: TagType) => {
             tagsById[t.id] = t.name;
         });
 
-        const posts: Post[] = postData.map((p) => ({
+        const posts: Post[] = postData.map((p: Post) => ({
             id: p.id,
             title: p.title ?? "",
             slug: p.slug ?? "",
@@ -54,11 +57,11 @@ export async function fetchBlogData(): Promise<BlogData> {
         }));
 
         const postsById: Record<string, Post> = {};
-        posts.forEach((p) => {
+        posts.forEach((p: Post) => {
             postsById[p.id] = p;
         });
 
-        const sections: Section[] = sectionData.map((s) => ({
+        const sections: Section[] = sectionData.map((s: Section) => ({
             id: s.id,
             title: s.title ?? "",
             slug: s.slug ?? "",
@@ -75,12 +78,12 @@ export async function fetchBlogData(): Promise<BlogData> {
         }));
 
         const sectionsById: Record<string, Section> = {};
-        sections.forEach((s) => {
+        sections.forEach((s: Section) => {
             sectionsById[s.id] = s;
         });
 
         // Map SectionPost relationships
-        sectionPostsRes.data.forEach((sp) => {
+        sectionPostsRes.data.forEach((sp: SectionPostType) => {
             const post = postsById[sp.postId];
             if (post) {
                 post.sectionIds.push(sp.sectionId);
@@ -92,7 +95,7 @@ export async function fetchBlogData(): Promise<BlogData> {
         });
 
         // Map PostTag relationships
-        postTagsRes.data.forEach((pt) => {
+        postTagsRes.data.forEach((pt: PostTagType) => {
             const post = postsById[pt.postId];
             const tagName = tagsById[pt.tagId];
             if (post && tagName) {
@@ -100,7 +103,7 @@ export async function fetchBlogData(): Promise<BlogData> {
             }
         });
 
-        const authors: Author[] = authorData.map((a) => ({
+        const authors: Author[] = authorData.map((a: Author) => ({
             id: a.id,
             name: a.authorName ?? "",
             avatar: a.avatar ?? "",


### PR DESCRIPTION
## Objectif
- typer les paramètres des callbacks dans le service de blog et les formulaires de contact

## Tests effectués
- `yarn exec prettier --write apps/web/src/services/blogDataService.ts apps/web/src/home/contact-section/contactForm/mapCGU/index.tsx apps/web/src/home/contact-section/contactForm/mapContactQuestions/index.tsx`
- `yarn lint` *(échoué : configuration ESLint invalide)*
- `yarn typecheck` *(échoué : dépendances non construites)*

------
https://chatgpt.com/codex/tasks/task_e_68ba77b0f6b88324a0dc34fa48cb0066