### PR TITLE
[Fix] sécurise l'utilisation d'Object.keys dans les utilitaires de profil

### DIFF
--- a/apps/web/src/components/Profile/utilsUserName.tsx
+++ b/apps/web/src/components/Profile/utilsUserName.tsx
@@ -1,13 +1,12 @@
 import { toUserNameForm } from "@domain/models/userName/form";
 import { type UserNameTypeUpdateInput } from "@types/models/userName/types";
 
-export const label = (field: keyof UserNameTypeUpdateInput): string => {
-    switch (field) {
-        case "userName":
-            return "Pseudo public";
-        default:
-            return field;
-    }
+const labels: Partial<Record<keyof UserNameTypeUpdateInput, string>> = {
+    userName: "Pseudo public",
 };
+
+export const label = (field: keyof UserNameTypeUpdateInput): string => labels[field] ?? field;
+
+export const fields = Object.keys(labels) as string[];
 
 export const normalizeFormData = toUserNameForm;

--- a/apps/web/src/components/Profile/utilsUserProfile.tsx
+++ b/apps/web/src/components/Profile/utilsUserProfile.tsx
@@ -1,24 +1,18 @@
 import { toUserProfileForm } from "@domain/models/userProfile/form";
 import { type UserProfileTypeUpdateInput } from "@types/models/userProfile/types";
-export const label = (field: keyof UserProfileTypeUpdateInput): string => {
-    switch (field) {
-        case "firstName":
-            return "Prénom";
-        case "familyName":
-            return "Nom";
-        case "address":
-            return "Adresse";
-        case "postalCode":
-            return "Code postal";
-        case "city":
-            return "Ville";
-        case "country":
-            return "Pays";
-        case "phoneNumber":
-            return "Téléphone";
-        default:
-            return field;
-    }
+
+const labels: Partial<Record<keyof UserProfileTypeUpdateInput, string>> = {
+    firstName: "Prénom",
+    familyName: "Nom",
+    address: "Adresse",
+    postalCode: "Code postal",
+    city: "Ville",
+    country: "Pays",
+    phoneNumber: "Téléphone",
 };
+
+export const label = (field: keyof UserProfileTypeUpdateInput): string => labels[field] ?? field;
+
+export const fields = Object.keys(labels) as string[];
 
 export const normalizeFormData = toUserProfileForm;


### PR DESCRIPTION
## Description
- typage explicite des clés renvoyées par `Object.keys`
- simplification des fonctions `label`

## Tests effectués
- `yarn install`
- `yarn prettier apps/web/src/components/Profile/utilsUserName.tsx apps/web/src/components/Profile/utilsUserProfile.tsx -w`
- `yarn lint` *(échec: Configuration for rule "boundaries/element-types" is invalid)*
- `yarn tsc -noEmit` *(échec: Couldn't find a script named "tsc")*
- `yarn test` *(échec: vite-tsconfig-paths est un module ESM)*
- `yarn build` *(échec: Failed to collect page data)*

------
https://chatgpt.com/codex/tasks/task_e_68ba77c1dca483248c9be148773bf14b